### PR TITLE
getLogs API changes to return txHash, make contract arg optional.

### DIFF
--- a/pkg/eth/backend.go
+++ b/pkg/eth/backend.go
@@ -482,7 +482,7 @@ func (b *Backend) GetTransaction(ctx context.Context, txHash common.Hash) (*type
 
 // GetReceipts retrieves receipts for provided block hash
 func (b *Backend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
-	_, receiptBytes, err := b.IPLDRetriever.RetrieveReceiptsByBlockHash(hash)
+	_, receiptBytes, txs, err := b.IPLDRetriever.RetrieveReceiptsByBlockHash(hash)
 	if err != nil {
 		return nil, err
 	}
@@ -492,6 +492,7 @@ func (b *Backend) GetReceipts(ctx context.Context, hash common.Hash) (types.Rece
 		if err := rlp.DecodeBytes(rctBytes, rct); err != nil {
 			return nil, err
 		}
+		rct.TxHash = common.HexToHash(txs[i])
 		rcts[i] = rct
 	}
 	return rcts, nil
@@ -499,7 +500,7 @@ func (b *Backend) GetReceipts(ctx context.Context, hash common.Hash) (types.Rece
 
 // GetLogs returns all the logs for the given block hash
 func (b *Backend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {
-	_, receiptBytes, err := b.IPLDRetriever.RetrieveReceiptsByBlockHash(hash)
+	_, receiptBytes, txs, err := b.IPLDRetriever.RetrieveReceiptsByBlockHash(hash)
 	if err != nil {
 		return nil, err
 	}
@@ -508,6 +509,10 @@ func (b *Backend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log
 		var rct types.Receipt
 		if err := rlp.DecodeBytes(rctBytes, &rct); err != nil {
 			return nil, err
+		}
+
+		for _, log := range rct.Logs {
+			log.TxHash = common.HexToHash(txs[i])
 		}
 
 		logs[i] = rct.Logs

--- a/pkg/eth/backend.go
+++ b/pkg/eth/backend.go
@@ -492,7 +492,7 @@ func (b *Backend) GetReceipts(ctx context.Context, hash common.Hash) (types.Rece
 		if err := rlp.DecodeBytes(rctBytes, rct); err != nil {
 			return nil, err
 		}
-		rct.TxHash = common.HexToHash(txs[i])
+		rct.TxHash = txs[i]
 		rcts[i] = rct
 	}
 	return rcts, nil
@@ -512,7 +512,7 @@ func (b *Backend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log
 		}
 
 		for _, log := range rct.Logs {
-			log.TxHash = common.HexToHash(txs[i])
+			log.TxHash = txs[i]
 		}
 
 		logs[i] = rct.Logs

--- a/pkg/eth/ipld_retriever.go
+++ b/pkg/eth/ipld_retriever.go
@@ -347,19 +347,19 @@ func (r *IPLDRetriever) RetrieveReceiptsByTxHashes(hashes []common.Hash) ([]stri
 }
 
 // RetrieveReceiptsByBlockHash returns the cids and rlp bytes for the receipts corresponding to the provided block hash
-func (r *IPLDRetriever) RetrieveReceiptsByBlockHash(hash common.Hash) ([]string, [][]byte, []string, error) {
+func (r *IPLDRetriever) RetrieveReceiptsByBlockHash(hash common.Hash) ([]string, [][]byte, []common.Hash, error) {
 	rctResults := make([]ipldResult, 0)
 	if err := r.db.Select(&rctResults, RetrieveReceiptsByBlockHashPgStr, hash.Hex()); err != nil {
 		return nil, nil, nil, err
 	}
 	cids := make([]string, len(rctResults))
 	rcts := make([][]byte, len(rctResults))
-	txs := make([]string, len(rctResults))
+	txs := make([]common.Hash, len(rctResults))
 
 	for i, res := range rctResults {
 		cids[i] = res.CID
 		rcts[i] = res.Data
-		txs[i] = res.TxHash
+		txs[i] = common.HexToHash(res.TxHash)
 	}
 
 	return cids, rcts, txs, nil

--- a/pkg/graphql/client.go
+++ b/pkg/graphql/client.go
@@ -21,8 +21,13 @@ type GetStorageAt struct {
 }
 
 type LogResponse struct {
-	Topics []common.Hash `json:"topics"`
-	Data   hexutil.Bytes `json:"data"`
+	Topics      []common.Hash   `json:"topics"`
+	Data        hexutil.Bytes   `json:"data"`
+	Transaction TransactionResp `json:"transaction"`
+}
+
+type TransactionResp struct {
+	Hash common.Hash `json:"hash"`
 }
 
 type GetLogs struct {
@@ -44,6 +49,9 @@ func (c *Client) GetLogs(ctx context.Context, hash common.Hash, address common.A
 			getLogs(blockHash: "%s", contract: "%s") {
 				data
 				topics
+				transaction {
+					hash
+				}
 			}
 		}
 	`, hash.String(), address.String())

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -1014,6 +1014,7 @@ func (r *Resolver) GetLogs(ctx context.Context, args struct {
 		return nil, err
 	}
 
+	var logIndexInBlock uint = 0
 	receipts := make(types.Receipts, len(receiptsBytes))
 	for index, receiptBytes := range receiptsBytes {
 		receiptCID := receiptCIDs[index]
@@ -1024,6 +1025,9 @@ func (r *Resolver) GetLogs(ctx context.Context, args struct {
 
 		receipts[index] = receipt
 		for _, log := range receipt.Logs {
+			log.Index = logIndexInBlock
+			logIndexInBlock++
+
 			if args.Contract == nil || *args.Contract == log.Address {
 				ret = append(ret, &Log{
 					backend:   r.backend,

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -1035,7 +1035,7 @@ func (r *Resolver) GetLogs(ctx context.Context, args struct {
 					cid:       receiptCID,
 					ipldBlock: receiptBytes,
 					transaction: &Transaction{
-						hash: common.HexToHash(txs[index]),
+						hash: txs[index],
 					},
 				})
 			}

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -1005,11 +1005,11 @@ func (r *Resolver) GetStorageAt(ctx context.Context, args struct {
 
 func (r *Resolver) GetLogs(ctx context.Context, args struct {
 	BlockHash common.Hash
-	Contract  common.Address
+	Contract  *common.Address
 }) (*[]*Log, error) {
 	ret := make([]*Log, 0, 10)
 
-	receiptCIDs, receiptsBytes, err := r.backend.IPLDRetriever.RetrieveReceiptsByBlockHash(args.BlockHash)
+	receiptCIDs, receiptsBytes, txs, err := r.backend.IPLDRetriever.RetrieveReceiptsByBlockHash(args.BlockHash)
 	if err != nil {
 		return nil, err
 	}
@@ -1024,12 +1024,15 @@ func (r *Resolver) GetLogs(ctx context.Context, args struct {
 
 		receipts[index] = receipt
 		for _, log := range receipt.Logs {
-			if log.Address == args.Contract {
+			if args.Contract == nil || *args.Contract == log.Address {
 				ret = append(ret, &Log{
 					backend:   r.backend,
 					log:       log,
 					cid:       receiptCID,
 					ipldBlock: receiptBytes,
+					transaction: &Transaction{
+						hash: common.HexToHash(txs[index]),
+					},
 				})
 			}
 		}

--- a/pkg/graphql/graphql_test.go
+++ b/pkg/graphql/graphql_test.go
@@ -161,8 +161,9 @@ var _ = Describe("GraphQL", func() {
 
 			expectedLogs := []graphql.LogResponse{
 				{
-					Topics: test_helpers.MockLog1.Topics,
-					Data:   hexutil.Bytes(test_helpers.MockLog1.Data),
+					Topics:      test_helpers.MockLog1.Topics,
+					Data:        hexutil.Bytes(test_helpers.MockLog1.Data),
+					Transaction: graphql.TransactionResp{Hash: test_helpers.MockTransactions[0].Hash()},
 				},
 			}
 			Expect(logs).To(Equal(expectedLogs))

--- a/pkg/graphql/schema.go
+++ b/pkg/graphql/schema.go
@@ -295,6 +295,6 @@ const schema string = `
         getStorageAt(blockHash: Bytes32!, contract: Address!, slot: Bytes32!): StorageResult
 
         # Get contract logs by block hash and contract address.
-        getLogs(blockHash: Bytes32!, contract: Address!): [Log!]
+        getLogs(blockHash: Bytes32!, contract: Address): [Log!]
     }
 `


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/116