### PR TITLE
Fix steps for integration test after geth update

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,7 +71,6 @@ jobs:
       STACK_ORCHESTRATOR_REF: 418957a1f745c921b21286c13bb033f922a91ae9
       GO_ETHEREUM_REF: "v1.10.18-statediff-4.0.2-alpha"
       IPLD_ETH_DB_REF: 91d30b9ea1acecd0a7f4307390a98bf3e289b8d7
-      DB_VALIDATOR: cc935dc97b216f2f9e03aa64acfd66e6d9dde124
       GOPATH: /tmp/go
       DB_WRITE: true
       ETH_FORWARD_ETH_CALLS: false
@@ -103,17 +102,12 @@ jobs:
           ref: ${{ env.IPLD_ETH_DB_REF }}
           repository: vulcanize/ipld-eth-db
           path: "./ipld-eth-db/"
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ env.DB_VALIDATOR }}
-          repository: vulcanize/ipld-eth-db-validator
-          path: "./ipld-eth-db-validator/"
       - name: Create config file
         run: |
           echo vulcanize_go_ethereum=$GITHUB_WORKSPACE/go-ethereum/ > ./config.sh
           echo vulcanize_ipld_eth_db=$GITHUB_WORKSPACE/ipld-eth-db/ >> ./config.sh
           echo vulcanize_ipld_eth_server=$GITHUB_WORKSPACE/ipld-eth-server/ >> ./config.sh
-          echo vulcanize_test_contract=$GITHUB_WORKSPACE/ipld-eth-db-validator/test/contract >> ./config.sh
+          echo vulcanize_test_contract=$GITHUB_WORKSPACE/ipld-eth-server/test/contract >> ./config.sh
           echo db_write=$DB_WRITE >> ./config.sh
           echo eth_forward_eth_calls=$ETH_FORWARD_ETH_CALLS >> ./config.sh
           echo eth_proxy_on_error=$ETH_PROXY_ON_ERROR >> ./config.sh
@@ -153,7 +147,6 @@ jobs:
       STACK_ORCHESTRATOR_REF: 418957a1f745c921b21286c13bb033f922a91ae9
       GO_ETHEREUM_REF: "v1.10.18-statediff-4.0.2-alpha"
       IPLD_ETH_DB_REF: 91d30b9ea1acecd0a7f4307390a98bf3e289b8d7
-      DB_VALIDATOR: cc935dc97b216f2f9e03aa64acfd66e6d9dde124
       GOPATH: /tmp/go
       DB_WRITE: false
       ETH_FORWARD_ETH_CALLS: true
@@ -185,17 +178,12 @@ jobs:
           ref: ${{ env.IPLD_ETH_DB_REF }}
           repository: vulcanize/ipld-eth-db
           path: "./ipld-eth-db/"
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ env.DB_VALIDATOR }}
-          repository: vulcanize/ipld-eth-db-validator
-          path: "./ipld-eth-db-validator/"
       - name: Create config file
         run: |
           echo vulcanize_go_ethereum=$GITHUB_WORKSPACE/go-ethereum/ > ./config.sh
           echo vulcanize_ipld_eth_db=$GITHUB_WORKSPACE/ipld-eth-db/ >> ./config.sh
           echo vulcanize_ipld_eth_server=$GITHUB_WORKSPACE/ipld-eth-server/ >> ./config.sh
-          echo vulcanize_test_contract=$GITHUB_WORKSPACE/ipld-eth-db-validator/test/contract >>./config.sh
+          echo vulcanize_test_contract=$GITHUB_WORKSPACE/ipld-eth-server/test/contract >>./config.sh
           echo db_write=$DB_WRITE >> ./config.sh
           echo eth_forward_eth_calls=$ETH_FORWARD_ETH_CALLS >> ./config.sh
           echo eth_proxy_on_error=$ETH_PROXY_ON_ERROR >> ./config.sh

--- a/test/README.md
+++ b/test/README.md
@@ -2,18 +2,24 @@
 
 ## Setup
 
-- Clone [stack-orchestrator](https://github.com/vulcanize/stack-orchestrator) and [go-ethereum](https://github.com/vulcanize/go-ethereum) repositories.
+- Clone [stack-orchestrator](https://github.com/vulcanize/stack-orchestrator), [ipld-eth-db](https://github.com/vulcanize/ipld-eth-db) [go-ethereum](https://github.com/vulcanize/go-ethereum) repositories.
 
-- Checkout [v4 release](https://github.com/vulcanize/go-ethereum/releases/tag/v1.10.17-statediff-4.0.1-alpha) in go-ethereum repo.
+- Checkout [v4 release](https://github.com/vulcanize/ipld-eth-db/releases/tag/v4.1.1-alpha) in ipld-eth-db repo.
+  ```bash
+  # In ipld-eth-db repo.
+  git checkout v4.1.1-alpha
+  ```
+
+- Checkout [v4 release](https://github.com/vulcanize/go-ethereum/releases/tag/v1.10.18-statediff-4.0.2-alpha) in go-ethereum repo.
   ```bash
   # In go-ethereum repo.
-  git checkout v1.10.17-statediff-4.0.1-alpha
+  git checkout v1.10.18-statediff-4.0.2-alpha
   ```
 
 - Checkout working commit in stack-orchestrator repo.
   ```bash
   # In stack-orchestrator repo.
-  git checkout 35c677433aee5fafdf74eb3c251a453691b818d0
+  git checkout 418957a1f745c921b21286c13bb033f922a91ae9
   ```
 
 ## Run
@@ -42,6 +48,9 @@
     ```bash
     #!/bin/bash
 
+    # Path to ipld-eth-server repo.
+    vulcanize_ipld_eth_db=~/ipld-eth-db/
+
     # Path to go-ethereum repo.
     vulcanize_go_ethereum=~/go-ethereum/
 
@@ -55,7 +64,10 @@
     eth_forward_eth_calls=false
     eth_proxy_on_error=false
     eth_http_path="go-ethereum:8545"
-      ```
+    ipld_eth_server_db_dependency=access-node
+    go_ethereum_db_dependency=access-node
+    connecting_db_name=vulcanize_testing_v4
+    ```
 
   - Run stack-orchestrator:
 
@@ -65,7 +77,8 @@
 
     ./wrapper.sh \
     -e docker \
-    -d ../docker/latest/docker-compose-db.yml \
+    -d ../docker/latest/docker-compose-timescale-db.yml \
+    -d ../docker/local/docker-compose-db-migration.yml \
     -d ../docker/local/docker-compose-go-ethereum.yml \
     -d ../docker/local/docker-compose-ipld-eth-server.yml \
     -d ../docker/local/docker-compose-contract.yml \
@@ -98,6 +111,9 @@
     eth_forward_eth_calls=true
     eth_proxy_on_error=false
     eth_http_path="go-ethereum:8545"
+    ipld_eth_server_db_dependency=access-node
+    go_ethereum_db_dependency=access-node
+    connecting_db_name=vulcanize_testing_v4
     ```
 
   - Stop the stack-orchestrator and start again using the same command


### PR DESCRIPTION
Related to https://github.com/vulcanize/ipld-eth-server/pull/162
Part of https://github.com/vulcanize/ipld-eth-server/issues/158

For running integration test, we use the [test contract docker](https://github.com/vulcanize/ipld-eth-server/tree/sharding/test/contract) from `ipld-eth-server`.
This PR removes use of `ipld-eth-db-validator` to run test contract docker and use the one from `ipld-eth-server`.

`stack-orchestrator` commit hash is from a branch in an [unmerged PR](https://github.com/vulcanize/stack-orchestrator/pull/23). Should merge that first and update hash if necessary.