### PR TITLE
Update transactions, receipts and logs queries

### DIFF
--- a/.github/workflows/on-pr-publish.yaml
+++ b/.github/workflows/on-pr-publish.yaml
@@ -28,9 +28,9 @@ jobs:
       BUILD_USERNAME: ${{ secrets.BUILD_USERNAME }}
       BUILD_KEY: ${{ secrets.BUILD_KEY }}
     with:
-      STACK_ORCHESTRATOR_REF: "382aca8e42bc5e33f301f77cdd2e09cc80602fc3"
+      STACK_ORCHESTRATOR_REF: "f2fd766f5400fcb9eb47b50675d2e3b1f2753702"
       GO_ETHEREUM_REF: "c265fdc30915e01bb633203acbbd9d5009a7ddf2"
-      IPLD_ETH_DB_REF: "4e948c58ce20c20ab633289f986d2ed2a1fe02ec"
+      IPLD_ETH_DB_REF: "b59505eab252670c622b42ce60621e9747fb64f9"
   build:
     name: Run docker build
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-publish.yaml
+++ b/.github/workflows/on-pr-publish.yaml
@@ -29,7 +29,7 @@ jobs:
       BUILD_KEY: ${{ secrets.BUILD_KEY }}
     with:
       STACK_ORCHESTRATOR_REF: "f2fd766f5400fcb9eb47b50675d2e3b1f2753702"
-      GO_ETHEREUM_REF: "c265fdc30915e01bb633203acbbd9d5009a7ddf2"
+      GO_ETHEREUM_REF: "7b4ef34de2b9469c3f82972b60e38b34c99c5382"
       IPLD_ETH_DB_REF: "b59505eab252670c622b42ce60621e9747fb64f9"
   build:
     name: Run docker build

--- a/.github/workflows/run_unit_test.sh
+++ b/.github/workflows/run_unit_test.sh
@@ -12,31 +12,17 @@ cd ipld-eth-server
 ## Remove the branch and github related info. This way future runs wont be confused.
 rm -f /tmp/git_head_ref /tmp/git_repository
 
-# Setup the DB
-cd $temp_dir
-git clone "https://github.com/vulcanize/ipld-eth-db.git"; cd ipld-eth-db; git checkout $(cat /tmp/ipld_eth_db_ref)
-
-# Spin Up DB using Stack Orchestrator
-cd $temp_dir
-git clone "https://github.com/vulcanize/stack-orchestrator.git"; cd stack-orchestrator; git checkout $(cat /tmp/stack_orchestrator_ref)
-
-cd ${temp_dir}/stack-orchestrator
-echo vulcanize_ipld_eth_db=${temp_dir}/ipld-eth-db > ./config.sh
-
-## Remove existing containers if they are present
-docker-compose -f docker/local/docker-compose-db-sharding.yml --env-file ./config.sh down -v --remove-orphans;
-
-trap 'cd ${temp_dir}/stack-orchestrator; docker-compose -f docker/local/docker-compose-db-sharding.yml --env-file ./config.sh down -v --remove-orphans; ' SIGINT SIGTERM
-docker-compose -f docker/local/docker-compose-db-sharding.yml --env-file ./config.sh up -d
+# Spin up DB and run migrations
+docker-compose up -d migrations ipld-eth-db
+trap "docker-compose down -v --remove-orphans; cd $start_dir ; rm -r $temp_dir" SIGINT SIGTERM ERR
+sleep 30
 
 # Remove old logs so there's no confusion, then run test
 rm -f /tmp/test.log /tmp/return_test.txt
-cd ${temp_dir}/ipld-eth-server
 PGPASSWORD=password DATABASE_USER=vdbm DATABASE_PORT=8077 DATABASE_PASSWORD=password DATABASE_HOSTNAME=localhost DATABASE_NAME=vulcanize_testing make test >  /tmp/test.log
 echo $? > /tmp/return_test.txt
 
 # Clean up
-
-cd ${temp_dir}/stack-orchestrator; docker-compose -f docker/local/docker-compose-db-sharding.yml --env-file ./config.sh down -v --remove-orphans
+docker-compose down -v --remove-orphans
 cd $start_dir
 rm -fr $temp_dir

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,12 +115,11 @@ jobs:
           echo vulcanize_ipld_eth_db=$GITHUB_WORKSPACE/ipld-eth-db/ >> ./config.sh
           echo vulcanize_ipld_eth_server=$GITHUB_WORKSPACE/ipld-eth-server/ >> ./config.sh
           echo vulcanize_test_contract=$GITHUB_WORKSPACE/ipld-eth-server/test/contract >> ./config.sh
+          echo genesis_file_path=start-up-files/go-ethereum/genesis.json >> ./config.sh
           echo db_write=$DB_WRITE >> ./config.sh
           echo eth_forward_eth_calls=$ETH_FORWARD_ETH_CALLS >> ./config.sh
           echo eth_proxy_on_error=$ETH_PROXY_ON_ERROR >> ./config.sh
           echo eth_http_path=$ETH_HTTP_PATH >> ./config.sh
-          echo watched_address_gap_filler_enabled=false >> ./config.sh
-          echo watched_address_gap_filler_interval=5 >> ./config.sh
           cat ./config.sh
       - name: Build geth
         run: |
@@ -184,12 +183,11 @@ jobs:
           echo vulcanize_ipld_eth_db=$GITHUB_WORKSPACE/ipld-eth-db/ >> ./config.sh
           echo vulcanize_ipld_eth_server=$GITHUB_WORKSPACE/ipld-eth-server/ >> ./config.sh
           echo vulcanize_test_contract=$GITHUB_WORKSPACE/ipld-eth-server/test/contract >>./config.sh
+          echo genesis_file_path=start-up-files/go-ethereum/genesis.json >> ./config.sh
           echo db_write=$DB_WRITE >> ./config.sh
           echo eth_forward_eth_calls=$ETH_FORWARD_ETH_CALLS >> ./config.sh
           echo eth_proxy_on_error=$ETH_PROXY_ON_ERROR >> ./config.sh
           echo eth_http_path=$ETH_HTTP_PATH >> ./config.sh
-          echo watched_address_gap_filler_enabled=false >> ./config.sh
-          echo watched_address_gap_filler_interval=5 >> ./config.sh
           cat ./config.sh
       - name: Build geth
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,8 +46,6 @@ jobs:
       - name: Output variables to files
         run: |
           echo $GITHUB_REPOSITORY > /tmp/git_repository
-          echo ${{ inputs.IPLD_ETH_DB_REF }} > /tmp/ipld_eth_db_ref
-          echo ${{ inputs.STACK_ORCHESTRATOR_REF }} > /tmp/stack_orchestrator_ref
           [ -z "$GITHUB_HEAD_REF" ] && echo $GITHUB_REF_NAME > /tmp/git_head_ref || echo $GITHUB_HEAD_REF > /tmp/git_head_ref
           echo "-----BEGIN OPENSSH PRIVATE KEY-----" >> /tmp/key
           echo ${{ env.BUILD_KEY }} >> /tmp/key
@@ -55,15 +53,11 @@ jobs:
           chmod 400 /tmp/key
           cat /tmp/git_repository
           cat /tmp/git_head_ref
-          cat /tmp/stack_orchestrator_ref
-          cat /tmp/ipld_eth_db_ref
 
       - name: Raw SCP
         run: |
           scp -o 'StrictHostKeyChecking no' -o UserKnownHostsFile=/dev/null -q -i /tmp/key /tmp/git_repository ${{ env.BUILD_USERNAME }}@${{ env.BUILD_HOSTNAME }}:/tmp/git_repository
           scp -o 'StrictHostKeyChecking no' -o UserKnownHostsFile=/dev/null -q -i /tmp/key /tmp/git_head_ref ${{ env.BUILD_USERNAME }}@${{ env.BUILD_HOSTNAME }}:/tmp/git_head_ref
-          scp -o 'StrictHostKeyChecking no' -o UserKnownHostsFile=/dev/null -q -i /tmp/key /tmp/stack_orchestrator_ref ${{ env.BUILD_USERNAME }}@${{ env.BUILD_HOSTNAME }}:/tmp/stack_orchestrator_ref
-          scp -o 'StrictHostKeyChecking no' -o UserKnownHostsFile=/dev/null -q -i /tmp/key /tmp/ipld_eth_db_ref ${{ env.BUILD_USERNAME }}@${{ env.BUILD_HOSTNAME }}:/tmp/ipld_eth_db_ref
           scp -o 'StrictHostKeyChecking no' -o UserKnownHostsFile=/dev/null -q -i /tmp/key .github/workflows/run_unit_test.sh ${{ env.BUILD_USERNAME }}@${{ env.BUILD_HOSTNAME }}:/tmp/run_unit_test.sh
 
       - name: Trigger Unit Test

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Additional, unique endpoints are exposed which utilize the new indexes and state
 
 ## Dependencies
 Minimal build dependencies
-* Go (1.13)
+* Go (1.18)
 * Git
 * GCC compiler
 * This repository
 
 External dependency
-* Postgres database populated by [ipld-eth-indexer](https://github.com/vulcanize/ipld-eth-indexer)
+* Postgres database populated by [ipld-eth-db](https://github.com/vulcanize/ipld-eth-db)
 
 ## Install
 Start by downloading ipld-eth-server and moving into the repo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,28 @@
 version: '3.2'
 
 services:
-  ipld-eth-db:
+  migrations:
     restart: on-failure
     depends_on:
-      - access-node
-    image: vulcanize/ipld-eth-db:v4.1.1-alpha
+      - ipld-eth-db
+    image: vulcanize/ipld-eth-db:v4.2.0-alpha
     environment:
       DATABASE_USER: "vdbm"
-      DATABASE_NAME: "vulcanize_testing_v4"
+      DATABASE_NAME: "vulcanize_testing"
       DATABASE_PASSWORD: "password"
-      DATABASE_HOSTNAME: "access-node"
+      DATABASE_HOSTNAME: "ipld-eth-db"
       DATABASE_PORT: 5432
+
+  ipld-eth-db:
+    image: timescale/timescaledb:latest-pg14
+    restart: always
+    command: ["postgres", "-c", "log_statement=all"]
+    environment:
+      POSTGRES_USER: "vdbm"
+      POSTGRES_DB: "vulcanize_testing"
+      POSTGRES_PASSWORD: "password"
+    ports:
+      - "127.0.0.1:8077:5432"
 
   eth-server:
     restart: unless-stopped
@@ -43,21 +54,6 @@ services:
       target: /tmp/chain.json
     ports:
      - "127.0.0.1:8081:8081"
-
-  graphql:
-    restart: unless-stopped
-    depends_on:
-      - ipld-eth-db
-    image: vulcanize/postgraphile:v1.0.1
-    environment:
-      - PG_HOST=db
-      - PG_PORT=5432
-      - PG_DATABASE=vulcanize_public
-      - PG_USER=vdbm
-      - PG_PASSWORD=password
-      - SCHEMA=public,eth
-    ports:
-      - "127.0.0.1:5000:5000"
 
 volumes:
   vdb_db_eth_server:

--- a/go.mod
+++ b/go.mod
@@ -289,4 +289,4 @@ require (
 	lukechampine.com/blake3 v1.1.6 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.10.19 => github.com/vulcanize/go-ethereum v1.10.19-statediff-4.0.2-alpha
+replace github.com/ethereum/go-ethereum v1.10.19 => github.com/vulcanize/go-ethereum v1.10.19-statediff-4.1.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1662,8 +1662,8 @@ github.com/vulcanize/eth-ipfs-state-validator/v4 v4.0.3-alpha h1:sDDK4eOdW3JEds+
 github.com/vulcanize/eth-ipfs-state-validator/v4 v4.0.3-alpha/go.mod h1:/pHfZd1IWsSTpCtGq6nnzUZBAkLV+zMrRh6Z3Hr3NFc=
 github.com/vulcanize/gap-filler v0.4.0 h1:5VD9PG7UrjEub4rLxZmstWoHnBnVtXz9silIVdrnTsM=
 github.com/vulcanize/gap-filler v0.4.0/go.mod h1:5awUyotIoJi6AuG0JPEm7SIwFZBD7Ecg0I8x7CdxcHI=
-github.com/vulcanize/go-ethereum v1.10.19-statediff-4.0.2-alpha h1:xD4fA2khoAnhBEk84JwrIEGvQCndVXpQGv5n7a9cgwc=
-github.com/vulcanize/go-ethereum v1.10.19-statediff-4.0.2-alpha/go.mod h1:5tMN+CDbK/qI2UlfN307HJykDmVIOCB1FM5RcHK9Kp8=
+github.com/vulcanize/go-ethereum v1.10.19-statediff-4.1.0-alpha h1:8ge2ban6t/e53XDwe6s28jcCevT7Ggo51lNJ0Eo1PgA=
+github.com/vulcanize/go-ethereum v1.10.19-statediff-4.1.0-alpha/go.mod h1:5tMN+CDbK/qI2UlfN307HJykDmVIOCB1FM5RcHK9Kp8=
 github.com/vulcanize/ipfs-ethdb/v4 v4.0.2-alpha h1:xak1uYmFWqJ2Hz3pM+0jDcqdlwYwRWeSkQV6B8IxD/0=
 github.com/vulcanize/ipfs-ethdb/v4 v4.0.2-alpha/go.mod h1:pHbLbW4Hk1IFpxrY9yi50IuoPPzmSY7lwOqpFAa369k=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=

--- a/pkg/eth/backend.go
+++ b/pkg/eth/backend.go
@@ -62,13 +62,8 @@ var (
 )
 
 const (
-	RetrieveCanonicalBlockHashByNumber = `SELECT block_hash FROM eth.header_cids
-									INNER JOIN public.blocks ON (
-										header_cids.mh_key = blocks.key
-										AND header_cids.block_number = blocks.block_number
-									)
-									WHERE block_hash = (SELECT canonical_header_hash($1))`
-	RetrieveCanonicalHeaderByNumber = `SELECT cid, data FROM eth.header_cids
+	RetrieveCanonicalBlockHashByNumber = `SELECT canonical_header_hash($1)`
+	RetrieveCanonicalHeaderByNumber    = `SELECT cid, data FROM eth.header_cids
 									INNER JOIN public.blocks ON (
 										header_cids.mh_key = blocks.key
 										AND header_cids.block_number = blocks.block_number

--- a/pkg/eth/backend.go
+++ b/pkg/eth/backend.go
@@ -56,6 +56,7 @@ var (
 	errNegativeBlockNumber    = errors.New("negative block number not supported")
 	errHeaderHashNotFound     = errors.New("header for hash not found")
 	errHeaderNotFound         = errors.New("header not found")
+	errMultipleHeadersForHash = errors.New("more than one headers for the given hash")
 	errTxHashNotFound         = errors.New("transaction for hash not found")
 	errTxHashInMultipleBlocks = errors.New("transaction for hash found in more than one canonical block")
 

--- a/pkg/eth/cid_retriever.go
+++ b/pkg/eth/cid_retriever.go
@@ -737,7 +737,7 @@ func (ecr *CIDRetriever) RetrieveTxCIDByHash(txHash string) (TransactionCIDRecor
 
 	var txCID TransactionCIDRecord
 
-	err := ecr.gormDB.Joins("IPLD").First(&txCID, "tx_hash = ?", txHash).Error
+	err := ecr.gormDB.Joins("IPLD").Find(&txCID, "tx_hash = ? AND transaction_cids.header_id = (SELECT canonical_header_hash(transaction_cids.block_number))", txHash).Error
 	if err != nil {
 		log.Error("header cid retrieval error")
 		return txCID, err

--- a/pkg/eth/cid_retriever.go
+++ b/pkg/eth/cid_retriever.go
@@ -191,7 +191,7 @@ func (ecr *CIDRetriever) Retrieve(filter SubscriptionSettings, blockNumber int64
 		}
 		// Retrieve cached receipt CIDs
 		if !filter.ReceiptFilter.Off {
-			cw.Receipts, err = ecr.RetrieveRctCIDsByHeaderID(tx, filter.ReceiptFilter, header.BlockHash, trxHashes)
+			cw.Receipts, err = ecr.RetrieveRctCIDs(tx, filter.ReceiptFilter, 0, header.BlockHash, trxHashes)
 			if err != nil {
 				log.Error("receipt cid retrieval error")
 				return nil, true, err
@@ -257,8 +257,8 @@ func (ecr *CIDRetriever) RetrieveTxCIDs(tx *sqlx.Tx, txFilter TxFilter, headerID
 	results := make([]models.TxModel, 0)
 	id := 1
 	pgStr := fmt.Sprintf(`SELECT CAST(transaction_cids.block_number as Text), transaction_cids.tx_hash,
-				transaction_cids.header_id,transaction_cids.cid, transaction_cids.mh_key, transaction_cids.dst,
-				transaction_cids.src, transaction_cids.index, transaction_cids.tx_data
+				transaction_cids.header_id, transaction_cids.cid, transaction_cids.mh_key, transaction_cids.dst,
+				transaction_cids.src, transaction_cids.index, transaction_cids.tx_data, transaction_cids.tx_type
 				FROM eth.transaction_cids
 				INNER JOIN eth.header_cids ON (
 						transaction_cids.header_id = header_cids.block_hash
@@ -358,29 +358,6 @@ func receiptFilterConditions(id *int, pgStr string, args []interface{}, rctFilte
 	return pgStr, args
 }
 
-// RetrieveRctCIDsByHeaderID retrieves and returns all of the rct cids at the provided header ID that conform to the provided
-// filter parameters and correspond to the provided tx ids
-func (ecr *CIDRetriever) RetrieveRctCIDsByHeaderID(tx *sqlx.Tx, rctFilter ReceiptFilter, headerID string, trxHashes []string) ([]models.ReceiptModel, error) {
-	log.Debug("retrieving receipt cids for header id ", headerID)
-	args := make([]interface{}, 0, 4)
-	pgStr := `SELECT CAST(receipt_cids.block_number as Text), receipt_cids.tx_id, receipt_cids.leaf_cid,
-			receipt_cids.leaf_mh_key, receipt_cids.contract, receipt_cids.contract_hash
- 			FROM eth.receipt_cids, eth.transaction_cids, eth.header_cids
-			WHERE receipt_cids.tx_id = transaction_cids.tx_hash
-			AND receipt_cids.block_number = transaction_cids.block_number
-			AND transaction_cids.header_id = header_cids.block_hash
-			AND transaction_cids.block_number = header_cids.block_number
-			AND header_cids.block_hash = $1`
-	id := 2
-	args = append(args, headerID)
-
-	pgStr, args = receiptFilterConditions(&id, pgStr, args, rctFilter, trxHashes)
-
-	pgStr += ` ORDER BY transaction_cids.index`
-	receiptCIDs := make([]models.ReceiptModel, 0)
-	return receiptCIDs, tx.Select(&receiptCIDs, pgStr, args...)
-}
-
 // RetrieveFilteredGQLLogs retrieves and returns all the log CIDs provided blockHash that conform to the provided
 // filter parameters.
 func (ecr *CIDRetriever) RetrieveFilteredGQLLogs(tx *sqlx.Tx, rctFilter ReceiptFilter, blockHash *common.Hash) ([]LogResult, error) {
@@ -388,12 +365,15 @@ func (ecr *CIDRetriever) RetrieveFilteredGQLLogs(tx *sqlx.Tx, rctFilter ReceiptF
 	args := make([]interface{}, 0, 4)
 	id := 1
 	pgStr := `SELECT CAST(eth.log_cids.block_number as Text), eth.log_cids.leaf_cid, eth.log_cids.index, eth.log_cids.rct_id,
-       			eth.log_cids.address, eth.log_cids.topic0, eth.log_cids.topic1, eth.log_cids.topic2, eth.log_cids.topic3,
-       			eth.log_cids.log_data, eth.transaction_cids.tx_hash, data, eth.receipt_cids.leaf_cid as cid, eth.receipt_cids.post_status
+			eth.log_cids.address, eth.log_cids.topic0, eth.log_cids.topic1, eth.log_cids.topic2, eth.log_cids.topic3,
+			eth.log_cids.log_data, eth.transaction_cids.tx_hash, eth.transaction_cids.index as txn_index, data,
+			eth.receipt_cids.leaf_cid as cid, eth.receipt_cids.post_status, header_cids.block_hash
 				FROM eth.log_cids, eth.receipt_cids, eth.transaction_cids, eth.header_cids, public.blocks
 				WHERE eth.log_cids.rct_id = receipt_cids.tx_id
+				AND eth.log_cids.header_id = eth.receipt_cids.header_id
 				AND eth.log_cids.block_number = eth.receipt_cids.block_number
 				AND receipt_cids.tx_id = transaction_cids.tx_hash
+				AND receipt_cids.header_id = transaction_cids.header_id
 				AND receipt_cids.block_number = transaction_cids.block_number
 				AND transaction_cids.header_id = header_cids.block_hash
 				AND transaction_cids.block_number = header_cids.block_number
@@ -416,19 +396,21 @@ func (ecr *CIDRetriever) RetrieveFilteredGQLLogs(tx *sqlx.Tx, rctFilter ReceiptF
 	return logCIDs, nil
 }
 
-// RetrieveFilteredLog retrieves and returns all the log cIDs provided blockHeight or blockHash that conform to the provided
+// RetrieveFilteredLog retrieves and returns all the log CIDs provided blockHeight or blockHash that conform to the provided
 // filter parameters.
 func (ecr *CIDRetriever) RetrieveFilteredLog(tx *sqlx.Tx, rctFilter ReceiptFilter, blockNumber int64, blockHash *common.Hash) ([]LogResult, error) {
 	log.Debug("retrieving log cids for receipt ids")
 	args := make([]interface{}, 0, 4)
 	pgStr := `SELECT CAST(eth.log_cids.block_number as Text), eth.log_cids.leaf_cid, eth.log_cids.index, eth.log_cids.rct_id,
-       			eth.log_cids.address, eth.log_cids.topic0, eth.log_cids.topic1, eth.log_cids.topic2, eth.log_cids.topic3,
-       			eth.log_cids.log_data, eth.transaction_cids.tx_hash, eth.transaction_cids.index as txn_index,
-       			header_cids.block_hash, CAST(header_cids.block_number as Text)
+			eth.log_cids.address, eth.log_cids.topic0, eth.log_cids.topic1, eth.log_cids.topic2, eth.log_cids.topic3,
+			eth.log_cids.log_data, eth.transaction_cids.tx_hash, eth.transaction_cids.index as txn_index,
+			eth.receipt_cids.leaf_cid as cid, eth.receipt_cids.post_status, header_cids.block_hash
 							FROM eth.log_cids, eth.receipt_cids, eth.transaction_cids, eth.header_cids
 							WHERE eth.log_cids.rct_id = receipt_cids.tx_id
+							AND eth.log_cids.header_id = eth.receipt_cids.header_id
 							AND eth.log_cids.block_number = eth.receipt_cids.block_number
 							AND receipt_cids.tx_id = transaction_cids.tx_hash
+							AND receipt_cids.header_id = transaction_cids.header_id
 							AND receipt_cids.block_number = transaction_cids.block_number
 							AND transaction_cids.header_id = header_cids.block_hash
 							AND transaction_cids.block_number = header_cids.block_number`
@@ -458,13 +440,14 @@ func (ecr *CIDRetriever) RetrieveFilteredLog(tx *sqlx.Tx, rctFilter ReceiptFilte
 
 // RetrieveRctCIDs retrieves and returns all of the rct cids at the provided blockheight or block hash that conform to the provided
 // filter parameters and correspond to the provided tx ids
-func (ecr *CIDRetriever) RetrieveRctCIDs(tx *sqlx.Tx, rctFilter ReceiptFilter, blockNumber int64, blockHash *common.Hash, txHashes []string) ([]models.ReceiptModel, error) {
+func (ecr *CIDRetriever) RetrieveRctCIDs(tx *sqlx.Tx, rctFilter ReceiptFilter, blockNumber int64, blockHash string, txHashes []string) ([]models.ReceiptModel, error) {
 	log.Debug("retrieving receipt cids for block ", blockNumber)
 	args := make([]interface{}, 0, 5)
-	pgStr := `SELECT CAST(receipt_cids.block_number as Text), receipt_cids.tx_id, receipt_cids.leaf_cid,
-			receipt_cids.leaf_mh_key,
+	pgStr := `SELECT CAST(receipt_cids.block_number as Text), receipt_cids.header_id, receipt_cids.tx_id,
+			receipt_cids.leaf_cid, receipt_cids.leaf_mh_key, receipt_cids.contract, receipt_cids.contract_hash
  			FROM eth.receipt_cids, eth.transaction_cids, eth.header_cids
 			WHERE receipt_cids.tx_id = transaction_cids.tx_hash
+			AND receipt_cids.header_id = transaction_cids.header_id
 			AND receipt_cids.block_number = transaction_cids.block_number
 			AND transaction_cids.header_id = header_cids.block_hash
 			AND transaction_cids.block_number = header_cids.block_number`
@@ -474,9 +457,9 @@ func (ecr *CIDRetriever) RetrieveRctCIDs(tx *sqlx.Tx, rctFilter ReceiptFilter, b
 		args = append(args, blockNumber)
 		id++
 	}
-	if blockHash != nil {
+	if blockHash != "" {
 		pgStr += fmt.Sprintf(` AND header_cids.block_hash = $%d`, id)
-		args = append(args, blockHash.String())
+		args = append(args, blockHash)
 		id++
 	}
 
@@ -609,7 +592,7 @@ func (ecr *CIDRetriever) RetrieveBlockByHash(blockHash common.Hash) (models.Head
 		txHashes[i] = txCID.TxHash
 	}
 	var rctCIDs []models.ReceiptModel
-	rctCIDs, err = ecr.RetrieveReceiptCIDsByTxIDs(tx, txHashes)
+	rctCIDs, err = ecr.RetrieveReceiptCIDsByByHeaderIDAndTxIDs(tx, headerCID.BlockHash, txHashes, blockNumber)
 	if err != nil {
 		log.Error("rct cid retrieval error")
 	}
@@ -662,7 +645,7 @@ func (ecr *CIDRetriever) RetrieveBlockByNumber(blockNumber int64) (models.Header
 		txHashes[i] = txCID.TxHash
 	}
 	var rctCIDs []models.ReceiptModel
-	rctCIDs, err = ecr.RetrieveReceiptCIDsByTxIDs(tx, txHashes)
+	rctCIDs, err = ecr.RetrieveReceiptCIDsByByHeaderIDAndTxIDs(tx, headerCID[0].BlockHash, txHashes, blockNumber)
 	if err != nil {
 		log.Error("rct cid retrieval error")
 	}
@@ -691,18 +674,21 @@ func (ecr *CIDRetriever) RetrieveTxCIDsByHeaderID(tx *sqlx.Tx, headerID string, 
 	return txCIDs, tx.Select(&txCIDs, pgStr, headerID, blockNumber)
 }
 
-// RetrieveReceiptCIDsByTxIDs retrieves receipt CIDs by their associated tx IDs
-func (ecr *CIDRetriever) RetrieveReceiptCIDsByTxIDs(tx *sqlx.Tx, txHashes []string) ([]models.ReceiptModel, error) {
+// RetrieveReceiptCIDsByByHeaderIDAndTxIDs retrieves receipt CIDs by their associated tx IDs for the given header id
+func (ecr *CIDRetriever) RetrieveReceiptCIDsByByHeaderIDAndTxIDs(tx *sqlx.Tx, headerID string, txHashes []string, blockNumber int64) ([]models.ReceiptModel, error) {
 	log.Debugf("retrieving receipt cids for tx hashes %v", txHashes)
-	pgStr := `SELECT CAST(receipt_cids.block_number as Text), receipt_cids.tx_id, receipt_cids.leaf_cid, receipt_cids.leaf_mh_key,
- 			receipt_cids.contract, receipt_cids.contract_hash
+	pgStr := `SELECT CAST(receipt_cids.block_number as Text), receipt_cids.header_id, receipt_cids.tx_id, receipt_cids.leaf_cid,
+			receipt_cids.leaf_mh_key, receipt_cids.contract, receipt_cids.contract_hash
 			FROM eth.receipt_cids, eth.transaction_cids
-			WHERE tx_id = ANY($1)
+			WHERE tx_id = ANY($2)
 			AND receipt_cids.tx_id = transaction_cids.tx_hash
+			AND receipt_cids.header_id = transaction_cids.header_id
 			AND receipt_cids.block_number = transaction_cids.block_number
+			AND transaction_cids.header_id = $1
+			AND transaction_cids.block_number = $3
 			ORDER BY transaction_cids.index`
 	var rctCIDs []models.ReceiptModel
-	return rctCIDs, tx.Select(&rctCIDs, pgStr, pq.Array(txHashes))
+	return rctCIDs, tx.Select(&rctCIDs, pgStr, headerID, pq.Array(txHashes), blockNumber)
 }
 
 // RetrieveHeaderAndTxCIDsByBlockNumber retrieves header CIDs and their associated tx CIDs by block number

--- a/pkg/eth/cid_retriever.go
+++ b/pkg/eth/cid_retriever.go
@@ -730,7 +730,6 @@ func (ecr *CIDRetriever) RetrieveHeaderAndTxCIDsByBlockHash(blockHash common.Has
 	if len(headerCIDs) == 0 {
 		return HeaderCIDRecord{}, errHeaderHashNotFound
 	} else if len(headerCIDs) > 1 {
-		// a transaction can be part of a only one canonical block
 		return HeaderCIDRecord{}, errMultipleHeadersForHash
 	}
 

--- a/pkg/eth/test_helpers/test_data.go
+++ b/pkg/eth/test_helpers/test_data.go
@@ -301,6 +301,7 @@ var (
 	MockRctMetaPostPublish = []models.ReceiptModel{
 		{
 			BlockNumber:  "1",
+			HeaderID:     MockBlock.Hash().String(),
 			LeafCID:      Rct1CID.String(),
 			LeafMhKey:    Rct1MhKey,
 			Contract:     "",
@@ -308,6 +309,7 @@ var (
 		},
 		{
 			BlockNumber:  "1",
+			HeaderID:     MockBlock.Hash().String(),
 			LeafCID:      Rct2CID.String(),
 			LeafMhKey:    Rct2MhKey,
 			Contract:     "",
@@ -315,6 +317,7 @@ var (
 		},
 		{
 			BlockNumber:  "1",
+			HeaderID:     MockBlock.Hash().String(),
 			LeafCID:      Rct3CID.String(),
 			LeafMhKey:    Rct3MhKey,
 			Contract:     ContractAddress.String(),
@@ -322,6 +325,7 @@ var (
 		},
 		{
 			BlockNumber:  "1",
+			HeaderID:     MockBlock.Hash().String(),
 			LeafCID:      Rct4CID.String(),
 			LeafMhKey:    Rct4MhKey,
 			Contract:     "",

--- a/pkg/shared/functions.go
+++ b/pkg/shared/functions.go
@@ -55,6 +55,13 @@ func FetchIPLDByMhKeyAndBlockNumber(tx *sqlx.Tx, mhKey string, blockNumber uint6
 	return block, tx.Get(&block, pgStr, mhKey, blockNumber)
 }
 
+// FetchIPLD is used to retrieve an IPLD from Postgres mhkey and blockNumber
+func FetchIPLD(db *sqlx.DB, mhKey string, blockNumber uint64) ([]byte, error) {
+	pgStr := `SELECT data FROM public.blocks WHERE key = $1 AND block_number = $2`
+	var block []byte
+	return block, db.Get(&block, pgStr, mhKey, blockNumber)
+}
+
 // MultihashKeyFromCID converts a cid into a blockstore-prefixed multihash db key string
 func MultihashKeyFromCID(c cid.Cid) string {
 	dbKey := dshelp.MultihashToDsKey(c.Hash())

--- a/scripts/run_unit_test.sh
+++ b/scripts/run_unit_test.sh
@@ -1,26 +1,16 @@
 #!/bin/bash
 
-set -e
+# Remove any existing containers / volumes
+docker-compose down --remove-orphans --volumes
 
-mkdir -p out
-
-# Remove existing docker-tsdb directory
-rm -rf out/docker-tsdb/
-
-# Copy over files to setup TimescaleDB
-ID=$(docker create vulcanize/ipld-eth-db:v4.1.1-alpha)
-docker cp $ID:/app/docker-tsdb out/docker-tsdb/
-docker rm -v $ID
-
-# Spin up TimescaleDB
-docker-compose -f out/docker-tsdb/docker-compose.test.yml -f docker-compose.yml up ipld-eth-db
-trap "docker-compose -f out/docker-tsdb/docker-compose.test.yml -f docker-compose.yml down --remove-orphans --volumes; rm -rf out/" SIGINT SIGTERM ERR
-sleep 45
+# Spin up DB and run migrations
+docker-compose up -d migrations ipld-eth-db
+sleep 30
 
 # Run unit tests
 go clean -testcache
-PGPASSWORD=password DATABASE_USER=vdbm DATABASE_PORT=8066 DATABASE_PASSWORD=password DATABASE_HOSTNAME=127.0.0.1 DATABASE_NAME=vulcanize_testing_v4 make test
+PGPASSWORD=password DATABASE_USER=vdbm DATABASE_PORT=8077 DATABASE_PASSWORD=password DATABASE_HOSTNAME=127.0.0.1 DATABASE_NAME=vulcanize_testing make test
 
 # Clean up
-docker-compose -f out/docker-tsdb/docker-compose.test.yml -f docker-compose.yml down --remove-orphans --volumes
+docker-compose down --remove-orphans --volumes
 rm -rf out/

--- a/test/README.md
+++ b/test/README.md
@@ -60,6 +60,7 @@
     # Path to test contract.
     vulcanize_test_contract=~/ipld-eth-server/test/contract
 
+    genesis_file_path='start-up-files/go-ethereum/genesis.json'
     db_write=true
     eth_forward_eth_calls=false
     eth_proxy_on_error=false
@@ -103,6 +104,7 @@
     # Path to test contract.
     vulcanize_test_contract=~/ipld-eth-server/test/contract
 
+    genesis_file_path='start-up-files/go-ethereum/genesis.json'
     db_write=false
     eth_forward_eth_calls=true
     eth_proxy_on_error=false

--- a/test/README.md
+++ b/test/README.md
@@ -4,22 +4,22 @@
 
 - Clone [stack-orchestrator](https://github.com/vulcanize/stack-orchestrator), [ipld-eth-db](https://github.com/vulcanize/ipld-eth-db) [go-ethereum](https://github.com/vulcanize/go-ethereum) repositories.
 
-- Checkout [v4 release](https://github.com/vulcanize/ipld-eth-db/releases/tag/v4.1.1-alpha) in ipld-eth-db repo.
+- Checkout [v4 release](https://github.com/vulcanize/ipld-eth-db/releases/tag/v4.2.0-alpha) in ipld-eth-db repo.
   ```bash
   # In ipld-eth-db repo.
-  git checkout v4.1.1-alpha
+  git checkout v4.2.0-alpha
   ```
 
-- Checkout [v4 release](https://github.com/vulcanize/go-ethereum/releases/tag/v1.10.18-statediff-4.0.2-alpha) in go-ethereum repo.
+- Checkout [v4 release](https://github.com/vulcanize/go-ethereum/releases/tag/v1.10.19-statediff-4.1.0-alpha) in go-ethereum repo.
   ```bash
   # In go-ethereum repo.
-  git checkout v1.10.18-statediff-4.0.2-alpha
+  git checkout v1.10.19-statediff-4.1.0-alpha
   ```
 
 - Checkout working commit in stack-orchestrator repo.
   ```bash
   # In stack-orchestrator repo.
-  git checkout 418957a1f745c921b21286c13bb033f922a91ae9
+  git checkout f2fd766f5400fcb9eb47b50675d2e3b1f2753702
   ```
 
 ## Run
@@ -64,9 +64,6 @@
     eth_forward_eth_calls=false
     eth_proxy_on_error=false
     eth_http_path="go-ethereum:8545"
-    ipld_eth_server_db_dependency=access-node
-    go_ethereum_db_dependency=access-node
-    connecting_db_name=vulcanize_testing_v4
     ```
 
   - Run stack-orchestrator:
@@ -77,8 +74,7 @@
 
     ./wrapper.sh \
     -e docker \
-    -d ../docker/latest/docker-compose-timescale-db.yml \
-    -d ../docker/local/docker-compose-db-migration.yml \
+    -d ../docker/local/docker-compose-db-sharding.yml \
     -d ../docker/local/docker-compose-go-ethereum.yml \
     -d ../docker/local/docker-compose-ipld-eth-server.yml \
     -d ../docker/local/docker-compose-contract.yml \
@@ -111,9 +107,6 @@
     eth_forward_eth_calls=true
     eth_proxy_on_error=false
     eth_http_path="go-ethereum:8545"
-    ipld_eth_server_db_dependency=access-node
-    go_ethereum_db_dependency=access-node
-    connecting_db_name=vulcanize_testing_v4
     ```
 
   - Stop the stack-orchestrator and start again using the same command


### PR DESCRIPTION
Part of https://github.com/vulcanize/ipld-eth-server/issues/170 and https://github.com/vulcanize/ipld-eth-server/issues/174
Requires https://github.com/vulcanize/ipld-eth-db/pull/100 and https://github.com/vulcanize/go-ethereum/pull/256

- Update queries according to schema changes
- Fix `eth_getTransactionByHash` implementation
- Avoid using `LIMIT 1` in queries where we expect a single row result
- Fetch IPLD data in a separate query when retrieving latest account data or storage value