### PR TITLE
Use geth's eth API instead of ethclient on missing blocks for getHeaderByHash

### DIFF
--- a/pkg/eth/api.go
+++ b/pkg/eth/api.go
@@ -120,11 +120,10 @@ func (pea *PublicEthAPI) GetHeaderByHash(ctx context.Context, hash common.Hash) 
 	}
 
 	if pea.proxyOnError {
-		if header, err := pea.ethClient.HeaderByHash(ctx, hash); header != nil && err == nil {
+		var result map[string]interface{}
+		if err := pea.rpc.CallContext(ctx, &result, "eth_getHeaderByHash", hash); result != nil && err == nil {
 			go pea.writeStateDiffFor(hash)
-			if res, err := pea.rpcMarshalHeader(header); err != nil {
-				return res
-			}
+			return result
 		}
 	}
 


### PR DESCRIPTION
Part of https://github.com/vulcanize/ipld-eth-server/issues/180

- Use geth's eth API instead of ethclient on missing blocks for `getHeaderByHash`
  - To maintain compatibility with geth's eth API, `GetHeaderByHash()` is required to include `totalDifficulty` in the result
  - ethclient's `HeaderByHash` [method](https://github.com/ethereum/go-ethereum/blob/v1.10.20/ethclient/ethclient.go#L176) returns just the header object which doesn't have the `totalDifficulty`
  - Since geth's `getHeaderByHash` API [implementation](https://github.com/ethereum/go-ethereum/blob/v1.10.20/internal/ethapi/api.go#L708) includes `totalDifficulty` in the result, it is not required to be fetched separately 