### PR TITLE
Increase EVM timeout for eth-calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,19 +51,19 @@ TEST_CONNECT_STRING = postgresql://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATAB
 TEST_CONNECT_STRING_LOCAL = postgresql://$(USER)@$(HOST_NAME):$(PORT)/$(TEST_DB)?sslmode=disable
 
 .PHONY: test
-test: |  $(GOOSE)
+test:
 	go vet ./...
 	go fmt ./...
 	go run github.com/onsi/ginkgo/ginkgo  -r --skipPackage=test
 
 .PHONY: integrationtest
-integrationtest: | $(GOOSE)
+integrationtest:
 	go vet ./...
 	go fmt ./...
 	go run github.com/onsi/ginkgo/ginkgo -r test/ -v
 
 .PHONY: test_local
-test_local: | $(GOOSE)
+test_local:
 	go vet ./...
 	go fmt ./...
 	./scripts/run_unit_test.sh

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ import "fmt"
 const (
 	Major = 4       // Major version component of the current release
 	Minor = 1       // Minor version component of the current release
-	Patch = 5       // Patch version component of the current release
+	Patch = 9       // Patch version component of the current release
 	Meta  = "alpha" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
Part of https://github.com/vulcanize/ops/issues/172

- Increase EVM timeout for eth-calls from 5 sec to 30 sec to avoid failures in testing 