### PR TITLE
Optimize GQL and getBlock APIs

### DIFF
--- a/.github/workflows/run_unit_test.sh
+++ b/.github/workflows/run_unit_test.sh
@@ -17,7 +17,7 @@ rm -f /tmp/git_head_ref /tmp/git_repository
 echo 'docker-compose up -d migrations ipld-eth-db'
 docker-compose up -d migrations ipld-eth-db
 trap "docker-compose down -v --remove-orphans; cd $start_dir ; rm -r $temp_dir" SIGINT SIGTERM ERR
-sleep 30
+sleep 60
 
 # Remove old logs so there's no confusion, then run test
 rm -f /tmp/test.log /tmp/return_test.txt

--- a/.github/workflows/run_unit_test.sh
+++ b/.github/workflows/run_unit_test.sh
@@ -6,7 +6,7 @@ set -e
 start_dir=$(pwd)
 temp_dir=$(mktemp -d)
 cd $temp_dir
-echo "git clone -b $(cat /tmp/git_head_ref) https://github.com/$(cat /tmp/git_repository).git"
+
 git clone -b $(cat /tmp/git_head_ref) "https://github.com/$(cat /tmp/git_repository).git"
 cd ipld-eth-server
 

--- a/pkg/eth/backend.go
+++ b/pkg/eth/backend.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strconv"
 	"time"
 
 	validator "github.com/cerc-io/eth-ipfs-state-validator/v4/pkg"
@@ -364,8 +365,10 @@ func (b *Backend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Blo
 		return nil, err
 	}
 
+	blockNumber := header.Number.Uint64()
+
 	// Fetch uncles
-	uncles, err := b.GetUnclesByBlockHash(tx, hash)
+	uncles, err := b.GetUnclesByBlockHashAndNumber(tx, hash, blockNumber)
 	if err != nil && err != sql.ErrNoRows {
 		log.Error("error fetching uncles: ", err)
 		return nil, err
@@ -389,14 +392,14 @@ func (b *Backend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Blo
 	}
 
 	// Fetch transactions
-	transactions, err := b.GetTransactionsByBlockHash(tx, hash)
+	transactions, err := b.GetTransactionsByBlockHashAndNumber(tx, hash, blockNumber)
 	if err != nil && err != sql.ErrNoRows {
 		log.Error("error fetching transactions: ", err)
 		return nil, err
 	}
 
 	// Fetch receipts
-	receipts, err := b.GetReceiptsByBlockHash(tx, hash)
+	receipts, err := b.GetReceiptsByBlockHashAndNumber(tx, hash, blockNumber)
 	if err != nil && err != sql.ErrNoRows {
 		log.Error("error fetching receipts: ", err)
 		return nil, err
@@ -418,8 +421,8 @@ func (b *Backend) GetHeaderByBlockHash(tx *sqlx.Tx, hash common.Hash) (*types.He
 }
 
 // GetUnclesByBlockHash retrieves uncles for a provided block hash
-func (b *Backend) GetUnclesByBlockHash(tx *sqlx.Tx, hash common.Hash) ([]*types.Header, error) {
-	_, uncleBytes, err := b.IPLDRetriever.RetrieveUnclesByBlockHash(tx, hash)
+func (b *Backend) GetUnclesByBlockHashAndNumber(tx *sqlx.Tx, hash common.Hash, number uint64) ([]*types.Header, error) {
+	_, uncleBytes, err := b.IPLDRetriever.RetrieveUncles(tx, hash, number)
 	if err != nil {
 		return nil, err
 	}
@@ -439,8 +442,8 @@ func (b *Backend) GetUnclesByBlockHash(tx *sqlx.Tx, hash common.Hash) ([]*types.
 }
 
 // GetTransactionsByBlockHash retrieves transactions for a provided block hash
-func (b *Backend) GetTransactionsByBlockHash(tx *sqlx.Tx, hash common.Hash) (types.Transactions, error) {
-	_, transactionBytes, err := b.IPLDRetriever.RetrieveTransactionsByBlockHash(tx, hash)
+func (b *Backend) GetTransactionsByBlockHashAndNumber(tx *sqlx.Tx, hash common.Hash, number uint64) (types.Transactions, error) {
+	_, transactionBytes, err := b.IPLDRetriever.RetrieveTransactions(tx, hash, number)
 	if err != nil {
 		return nil, err
 	}
@@ -459,8 +462,8 @@ func (b *Backend) GetTransactionsByBlockHash(tx *sqlx.Tx, hash common.Hash) (typ
 }
 
 // GetReceiptsByBlockHash retrieves receipts for a provided block hash
-func (b *Backend) GetReceiptsByBlockHash(tx *sqlx.Tx, hash common.Hash) (types.Receipts, error) {
-	_, receiptBytes, txs, err := b.IPLDRetriever.RetrieveReceiptsByBlockHash(tx, hash)
+func (b *Backend) GetReceiptsByBlockHashAndNumber(tx *sqlx.Tx, hash common.Hash, number uint64) (types.Receipts, error) {
+	_, receiptBytes, txs, err := b.IPLDRetriever.RetrieveReceipts(tx, hash, number)
 	if err != nil {
 		return nil, err
 	}
@@ -523,20 +526,13 @@ func (b *Backend) GetReceipts(ctx context.Context, hash common.Hash) (types.Rece
 		}
 	}()
 
-	_, receiptBytes, txs, err := b.IPLDRetriever.RetrieveReceiptsByBlockHash(tx, hash)
+	headerCID, err := b.Retriever.RetrieveHeaderCIDByHash(tx, hash)
 	if err != nil {
 		return nil, err
 	}
-	rcts := make(types.Receipts, len(receiptBytes))
-	for i, rctBytes := range receiptBytes {
-		rct := new(types.Receipt)
-		if err := rct.UnmarshalBinary(rctBytes); err != nil {
-			return nil, err
-		}
-		rct.TxHash = txs[i]
-		rcts[i] = rct
-	}
-	return rcts, nil
+	blockNumber, _ := strconv.ParseUint(string(headerCID.BlockNumber), 10, 64)
+
+	return b.GetReceiptsByBlockHashAndNumber(tx, hash, blockNumber)
 }
 
 // GetLogs returns all the logs for the given block hash
@@ -557,7 +553,7 @@ func (b *Backend) GetLogs(ctx context.Context, hash common.Hash, number uint64) 
 		}
 	}()
 
-	_, receiptBytes, txs, err := b.IPLDRetriever.RetrieveReceiptsByBlockHash(tx, hash)
+	_, receiptBytes, txs, err := b.IPLDRetriever.RetrieveReceipts(tx, hash, number)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/eth/cid_retriever.go
+++ b/pkg/eth/cid_retriever.go
@@ -360,7 +360,7 @@ func receiptFilterConditions(id *int, pgStr string, args []interface{}, rctFilte
 
 // RetrieveFilteredGQLLogs retrieves and returns all the log CIDs provided blockHash that conform to the provided
 // filter parameters.
-func (ecr *CIDRetriever) RetrieveFilteredGQLLogs(tx *sqlx.Tx, rctFilter ReceiptFilter, blockHash *common.Hash) ([]LogResult, error) {
+func (ecr *CIDRetriever) RetrieveFilteredGQLLogs(tx *sqlx.Tx, rctFilter ReceiptFilter, blockHash *common.Hash, blockNumber *big.Int) ([]LogResult, error) {
 	log.Debug("retrieving log cids for receipt ids with block hash", blockHash.String())
 	args := make([]interface{}, 0, 4)
 	id := 1
@@ -378,6 +378,12 @@ func (ecr *CIDRetriever) RetrieveFilteredGQLLogs(tx *sqlx.Tx, rctFilter ReceiptF
 
 	args = append(args, blockHash.String())
 	id++
+
+	if blockNumber != nil {
+		pgStr += ` AND receipt_cids.block_number = $2`
+		id++
+		args = append(args, blockNumber.Int64())
+	}
 
 	pgStr, args = logFilterCondition(&id, pgStr, args, rctFilter)
 	pgStr += ` ORDER BY log_cids.index`

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -1272,7 +1272,7 @@ func (r *Resolver) AllEthHeaderCids(ctx context.Context, args struct {
 	var headerCIDs []eth.HeaderCIDRecord
 	var err error
 	if args.Condition.BlockHash != nil {
-		headerCID, err := r.backend.Retriever.RetrieveHeaderAndTxCIDsByBlockHash(common.HexToHash(*args.Condition.BlockHash))
+		headerCID, err := r.backend.Retriever.RetrieveHeaderAndTxCIDsByBlockHash(common.HexToHash(*args.Condition.BlockHash), args.Condition.BlockNumber.ToInt())
 		if err != nil {
 			if !strings.Contains(err.Error(), "not found") {
 				return nil, err

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -1356,6 +1356,8 @@ func (r *Resolver) EthTransactionCidByTxHash(ctx context.Context, args struct {
 	TxHash      string
 	BlockNumber *BigInt
 }) (*EthTransactionCID, error) {
+	// Need not check args.BlockNumber for nil as .ToInt() uses a pointer receiver and returns nil if BlockNumber is nil
+	// https://stackoverflow.com/questions/42238624/calling-a-method-on-a-nil-struct-pointer-doesnt-panic-why-not
 	txCID, err := r.backend.Retriever.RetrieveTxCIDByHash(args.TxHash, args.BlockNumber.ToInt())
 
 	if err != nil {

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -1353,9 +1353,10 @@ func (r *Resolver) AllEthHeaderCids(ctx context.Context, args struct {
 }
 
 func (r *Resolver) EthTransactionCidByTxHash(ctx context.Context, args struct {
-	TxHash string
+	TxHash      string
+	BlockNumber *BigInt
 }) (*EthTransactionCID, error) {
-	txCID, err := r.backend.Retriever.RetrieveTxCIDByHash(args.TxHash)
+	txCID, err := r.backend.Retriever.RetrieveTxCIDByHash(args.TxHash, args.BlockNumber.ToInt())
 
 	if err != nil {
 		return nil, err

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -1036,8 +1036,9 @@ func (r *Resolver) GetStorageAt(ctx context.Context, args struct {
 }
 
 func (r *Resolver) GetLogs(ctx context.Context, args struct {
-	BlockHash common.Hash
-	Addresses *[]common.Address
+	BlockHash   common.Hash
+	BlockNumber *BigInt
+	Addresses   *[]common.Address
 }) (*[]*Log, error) {
 	var filter eth.ReceiptFilter
 
@@ -1054,7 +1055,7 @@ func (r *Resolver) GetLogs(ctx context.Context, args struct {
 		return nil, err
 	}
 
-	filteredLogs, err := r.backend.Retriever.RetrieveFilteredGQLLogs(tx, filter, &args.BlockHash)
+	filteredLogs, err := r.backend.Retriever.RetrieveFilteredGQLLogs(tx, filter, &args.BlockHash, args.BlockNumber.ToInt())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graphql/graphql_test.go
+++ b/pkg/graphql/graphql_test.go
@@ -296,7 +296,7 @@ var _ = Describe("GraphQL", func() {
 			allEthHeaderCIDsResp, err := client.AllEthHeaderCIDs(ctx, graphql.EthHeaderCIDCondition{BlockHash: &blockHash})
 			Expect(err).ToNot(HaveOccurred())
 
-			headerCID, err := backend.Retriever.RetrieveHeaderAndTxCIDsByBlockHash(blocks[1].Hash())
+			headerCID, err := backend.Retriever.RetrieveHeaderAndTxCIDsByBlockHash(blocks[1].Hash(), nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(len(allEthHeaderCIDsResp.Nodes)).To(Equal(1))

--- a/pkg/graphql/graphql_test.go
+++ b/pkg/graphql/graphql_test.go
@@ -311,7 +311,7 @@ var _ = Describe("GraphQL", func() {
 			ethTransactionCIDResp, err := client.EthTransactionCIDByTxHash(ctx, txHash)
 			Expect(err).ToNot(HaveOccurred())
 
-			txCID, err := backend.Retriever.RetrieveTxCIDByHash(txHash)
+			txCID, err := backend.Retriever.RetrieveTxCIDByHash(txHash, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			compareEthTxCID(*ethTransactionCIDResp, txCID)

--- a/pkg/graphql/schema.go
+++ b/pkg/graphql/schema.go
@@ -349,6 +349,6 @@ const schema string = `
         allEthHeaderCids(condition: EthHeaderCidCondition): EthHeaderCidsConnection
 
         # PostGraphile alternative to get transactions using transaction hash.
-        ethTransactionCidByTxHash(txHash: String!): EthTransactionCid
+        ethTransactionCidByTxHash(txHash: String!, blockNumber: BigInt): EthTransactionCid
     }
 `

--- a/pkg/graphql/schema.go
+++ b/pkg/graphql/schema.go
@@ -343,7 +343,7 @@ const schema string = `
         getStorageAt(blockHash: Bytes32!, contract: Address!, slot: Bytes32!): StorageResult
 
         # Get contract logs by block hash and contract address.
-        getLogs(blockHash: Bytes32!, addresses: [Address!]): [Log!]
+        getLogs(blockHash: Bytes32!, blockNumber: BigInt, addresses: [Address!]): [Log!]
 
         # PostGraphile alternative to get headers with transactions using block number or block hash.
         allEthHeaderCids(condition: EthHeaderCidCondition): EthHeaderCidsConnection


### PR DESCRIPTION
Part of https://github.com/cerc-io/ipld-eth-server/issues/202, https://github.com/cerc-io/watcher-ts/issues/208

- Add optional block number argument to the `getLogs` API
- Use block number if passed while fetching block with transactions
- Use block number while fetching block objects (`uncles`, `transactions` and `receipts`) for `eth_getBlockByNumber` API
- Use block number when fetching a tx by `txHash`