### PR TITLE
211: ipld-eth-server http counters don't work

### DIFF
--- a/pkg/rpc/http.go
+++ b/pkg/rpc/http.go
@@ -35,8 +35,7 @@ func StartHTTPEndpoint(endpoint string, apis []rpc.API, modules []string, cors [
 	if err != nil {
 		utils.Fatalf("Could not register HTTP API: %w", err)
 	}
-	handler := node.NewHTTPHandlerStack(srv, cors, vhosts, nil)
-	handler = prom.HTTPMiddleware(handler)
+	handler := prom.HTTPMiddleware(node.NewHTTPHandlerStack(srv, cors, vhosts, nil))
 
 	// start http server
 	_, addr, err := node.StartHTTPEndpoint(endpoint, rpc.DefaultHTTPTimeouts, handler)

--- a/pkg/rpc/http.go
+++ b/pkg/rpc/http.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/cerc-io/ipld-eth-server/v4/pkg/prom"
 )
 
 // StartHTTPEndpoint starts the HTTP RPC endpoint, configured with cors/vhosts/modules.
@@ -34,6 +36,7 @@ func StartHTTPEndpoint(endpoint string, apis []rpc.API, modules []string, cors [
 		utils.Fatalf("Could not register HTTP API: %w", err)
 	}
 	handler := node.NewHTTPHandlerStack(srv, cors, vhosts, nil)
+	handler = prom.HTTPMiddleware(handler)
 
 	// start http server
 	_, addr, err := node.StartHTTPEndpoint(endpoint, rpc.DefaultHTTPTimeouts, handler)


### PR DESCRIPTION
Enable HTTP metrics.  More detail is in #211, but the necessary metrics code already existed, it just doesn't seem to be used.