### PR TITLE
Use blocks table, not header_cids, for getBlockNumber()

### DIFF
--- a/pkg/eth/cid_retriever.go
+++ b/pkg/eth/cid_retriever.go
@@ -117,14 +117,14 @@ func NewCIDRetriever(db *sqlx.DB) *CIDRetriever {
 // RetrieveFirstBlockNumber is used to retrieve the first block number in the db
 func (ecr *CIDRetriever) RetrieveFirstBlockNumber() (int64, error) {
 	var blockNumber int64
-	err := ecr.db.Get(&blockNumber, "SELECT block_number FROM eth.header_cids ORDER BY block_number ASC LIMIT 1")
+	err := ecr.db.Get(&blockNumber, "SELECT block_number FROM public.blocks ORDER BY block_number ASC LIMIT 1")
 	return blockNumber, err
 }
 
 // RetrieveLastBlockNumber is used to retrieve the latest block number in the db
 func (ecr *CIDRetriever) RetrieveLastBlockNumber() (int64, error) {
 	var blockNumber int64
-	err := ecr.db.Get(&blockNumber, "SELECT block_number FROM eth.header_cids ORDER BY block_number DESC LIMIT 1")
+	err := ecr.db.Get(&blockNumber, "SELECT block_number FROM public.blocks ORDER BY block_number DESC LIMIT 1")
 	return blockNumber, err
 }
 


### PR DESCRIPTION
On our machines, the single most expensive query is:

```
SELECT block_number FROM eth.header_cids ORDER BY block_number DESC LIMIT 1
```

This query touches gazillions of rows, almost certainly as a consequence of only having a BRIN index on header_cids.block_number.

Even using gibbon (which has a comparatively small DB vs rhino or vulture) the comparison is significant:

OLD:

```
"Limit  (cost=28471.11..28471.24 rows=1 width=8) (actual time=182.739..249.251 rows=1 loops=1)"
"  ->  Gather Merge  (cost=28471.11..102315.06 rows=610660 width=8) (actual time=182.738..249.249 rows=1 loops=1)"
"        Workers Planned: 5"
"        Workers Launched: 5"
"        ->  Sort  (cost=27471.04..27776.37 rows=122132 width=8) (actual time=164.437..164.437 rows=1 loops=6)"
"              Sort Key: block_number DESC"
"              Sort Method: top-N heapsort  Memory: 25kB"
"              Worker 0:  Sort Method: top-N heapsort  Memory: 25kB"
"              Worker 1:  Sort Method: top-N heapsort  Memory: 25kB"
"              Worker 2:  Sort Method: top-N heapsort  Memory: 25kB"
"              Worker 3:  Sort Method: top-N heapsort  Memory: 25kB"
"              Worker 4:  Sort Method: top-N heapsort  Memory: 25kB"
"              ->  Parallel Index Only Scan using header_cid_index on header_cids  (cost=0.55..26860.38 rows=122132 width=8) (actual time=0.069..155.067 rows=101663 loops=6)"
"                    Heap Fetches: 87419"
"Planning Time: 4.875 ms"
"Execution Time: 249.310 ms"
```

NEW:
```
"Limit  (cost=0.58..0.60 rows=1 width=8) (actual time=0.028..0.029 rows=1 loops=1)"
"  ->  Index Only Scan using blocks_block_number_idx on blocks  (cost=0.58..67751347.29 rows=2837035909 width=8) (actual time=0.028..0.028 rows=1 loops=1)"
"        Heap Fetches: 1"
"Planning Time: 0.091 ms"
"Execution Time: 0.047 ms"
```