### PR TITLE
Fix for getTransactionReceipt returning empty 'from' address.

### DIFF
--- a/pkg/eth/api.go
+++ b/pkg/eth/api.go
@@ -604,12 +604,7 @@ func (pea *PublicEthAPI) localGetTransactionReceipt(ctx context.Context, hash co
 	}
 	receipt := receipts[index]
 
-	var signer types.Signer
-	if tx.Protected() {
-		signer = types.LatestSignerForChainID(tx.ChainId())
-	} else {
-		signer = types.HomesteadSigner{}
-	}
+	signer := SignerForTx(tx)
 	from, _ := types.Sender(signer, tx)
 
 	fields := map[string]interface{}{

--- a/pkg/eth/api.go
+++ b/pkg/eth/api.go
@@ -604,9 +604,11 @@ func (pea *PublicEthAPI) localGetTransactionReceipt(ctx context.Context, hash co
 	}
 	receipt := receipts[index]
 
-	var signer types.Signer = types.FrontierSigner{}
+	var signer types.Signer
 	if tx.Protected() {
-		signer = types.NewEIP155Signer(tx.ChainId())
+		signer = types.LatestSignerForChainID(tx.ChainId())
+	} else {
+		signer = types.HomesteadSigner{}
 	}
 	from, _ := types.Sender(signer, tx)
 

--- a/pkg/eth/backend_utils.go
+++ b/pkg/eth/backend_utils.go
@@ -144,15 +144,21 @@ func NewRPCTransactionFromBlockHash(b *types.Block, hash common.Hash) *RPCTransa
 	return nil
 }
 
-// NewRPCTransaction returns a transaction that will serialize to the RPC
-// representation, with the given location metadata set (if available).
-func NewRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int) *RPCTransaction {
+// SignerForTx returns an appropriate Signer for this Transaction
+func SignerForTx(tx *types.Transaction) types.Signer {
 	var signer types.Signer
 	if tx.Protected() {
 		signer = types.LatestSignerForChainID(tx.ChainId())
 	} else {
 		signer = types.HomesteadSigner{}
 	}
+	return signer
+}
+
+// NewRPCTransaction returns a transaction that will serialize to the RPC
+// representation, with the given location metadata set (if available).
+func NewRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int) *RPCTransaction {
+	signer := SignerForTx(tx)
 	from, _ := types.Sender(signer, tx)
 	v, r, s := tx.RawSignatureValues()
 	result := &RPCTransaction{

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -243,10 +243,7 @@ func (t *Transaction) From(ctx context.Context, args BlockNumberArgs) (*Account,
 	if err != nil || tx == nil {
 		return nil, err
 	}
-	var signer types.Signer = types.HomesteadSigner{}
-	if tx.Protected() {
-		signer = types.NewEIP155Signer(tx.ChainId())
-	}
+	signer := eth.SignerForTx(tx)
 	from, _ := types.Sender(signer, tx)
 
 	return &Account{


### PR DESCRIPTION
Fixes a bug where the wrong signer is used for getTransactionReceipt, leading to a null 'from' value, and unifies the code used to obtain a Signer for a tx.