### PR TITLE
rlp.EncodeToBytes => tx.MarshalBinary

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/rlp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -147,10 +146,10 @@ var _ = Describe("Basic integration test", func() {
 
 			Expect(gethReceipt).To(Equal(ipldReceipt))
 
-			rlpGeth, err := rlp.EncodeToBytes(gethReceipt)
+			rlpGeth, err := gethReceipt.MarshalBinary()
 			Expect(err).ToNot(HaveOccurred())
 
-			rlpIpld, err := rlp.EncodeToBytes(ipldReceipt)
+			rlpIpld, err := ipldReceipt.MarshalBinary()
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(rlpGeth).To(Equal(rlpIpld))

--- a/pkg/eth/api.go
+++ b/pkg/eth/api.go
@@ -467,7 +467,7 @@ func (pea *PublicEthAPI) GetRawTransactionByHash(ctx context.Context, hash commo
 	// Retrieve a finalized transaction, or a pooled otherwise
 	tx, _, _, _, err := pea.B.GetTransaction(ctx, hash)
 	if tx != nil && err == nil {
-		return rlp.EncodeToBytes(tx)
+		return tx.MarshalBinary()
 	}
 	if pea.config.ProxyOnError {
 		var tx hexutil.Bytes

--- a/pkg/eth/api_test/api_test.go
+++ b/pkg/eth/api_test/api_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/statediff/indexer/interfaces"
 	"github.com/ethereum/go-ethereum/statediff/indexer/ipld"
@@ -136,9 +135,9 @@ var (
 	expectedTransaction2      = eth.NewRPCTransaction(test_helpers.MockTransactions[1], test_helpers.MockBlock.Hash(), test_helpers.MockBlock.NumberU64(), 1, test_helpers.MockBlock.BaseFee())
 	expectedTransaction3      = eth.NewRPCTransaction(test_helpers.MockTransactions[2], test_helpers.MockBlock.Hash(), test_helpers.MockBlock.NumberU64(), 2, test_helpers.MockBlock.BaseFee())
 	expectedLondonTransaction = eth.NewRPCTransaction(test_helpers.MockLondonTransactions[0], test_helpers.MockLondonBlock.Hash(), test_helpers.MockLondonBlock.NumberU64(), 0, test_helpers.MockLondonBlock.BaseFee())
-	expectRawTx, _            = rlp.EncodeToBytes(test_helpers.MockTransactions[0])
-	expectRawTx2, _           = rlp.EncodeToBytes(test_helpers.MockTransactions[1])
-	expectRawTx3, _           = rlp.EncodeToBytes(test_helpers.MockTransactions[2])
+	expectRawTx, _            = test_helpers.MockTransactions[0].MarshalBinary()
+	expectRawTx2, _           = test_helpers.MockTransactions[1].MarshalBinary()
+	expectRawTx3, _           = test_helpers.MockTransactions[2].MarshalBinary()
 	expectedReceipt           = map[string]interface{}{
 		"blockHash":         blockHash,
 		"blockNumber":       hexutil.Uint64(uint64(number.Int64())),

--- a/pkg/eth/backend_utils.go
+++ b/pkg/eth/backend_utils.go
@@ -275,7 +275,7 @@ func newRPCRawTransactionFromBlockIndex(b *types.Block, index uint64) hexutil.By
 	if index >= uint64(len(txs)) {
 		return nil
 	}
-	blob, _ := rlp.EncodeToBytes(txs[index])
+	blob, _ := txs[index].MarshalBinary()
 	return blob
 }
 


### PR DESCRIPTION
For #245 

While Thomas was testing geth vs ipld-eth-server output a discrepancy was identified with the "eth_getRawTransaction*" endpoints:

```
geth:
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": "0x02f86e8204bc42843b9aca00843b9aca0e82520894e22ad83a0de117ba0d03d5e94eb4e0d80a69c62a82117780c080a00fdcce5c89cf7cdece6aafdeb53ddd419708245bfb82c40429b95b903c3af487a00a82d20e108d6e4d9880911ec70bd50f123a091926fc949a9c8ff6189769bdde"
}
ipld-eth-server:
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": "0xb87102f86e8204bc42843b9aca00843b9aca0e82520894e22ad83a0de117ba0d03d5e94eb4e0d80a69c62a82117780c080a00fdcce5c89cf7cdece6aafdeb53ddd419708245bfb82c40429b95b903c3af487a00a82d20e108d6e4d9880911ec70bd50f123a091926fc949a9c8ff6189769bdde"
}
```

I suspect this is the issue, if it isn't- it is still an issue.