### PR TITLE
Fix getLogs query (avoid repeated execution, separate tx, and improve performance)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -325,6 +325,7 @@ func init() {
 	viper.BindPFlag("ethereum.forwardEthCalls", serveCmd.PersistentFlags().Lookup("eth-forward-eth-calls"))
 	viper.BindPFlag("ethereum.forwardGetStorageAt", serveCmd.PersistentFlags().Lookup("eth-forward-get-storage-at"))
 	viper.BindPFlag("ethereum.proxyOnError", serveCmd.PersistentFlags().Lookup("eth-proxy-on-error"))
+	viper.BindPFlag("ethereum.getLogsBlockLimit", serveCmd.PersistentFlags().Lookup("eth-getlogs-block-limit"))
 
 	// groupcache flags
 	viper.BindPFlag("groupcache.pool.enabled", serveCmd.PersistentFlags().Lookup("gcache-pool-enabled"))

--- a/pkg/eth/backend.go
+++ b/pkg/eth/backend.go
@@ -125,7 +125,7 @@ func (b *Backend) ChainDb() ethdb.Database {
 	return b.EthDB
 }
 
-func (b *Backend) normalizeBlockNumber(blockNumber rpc.BlockNumber) (int64, error) {
+func (b *Backend) NormalizeBlockNumber(blockNumber rpc.BlockNumber) (int64, error) {
 	var err error
 	number := blockNumber.Int64()
 	if blockNumber == rpc.LatestBlockNumber {
@@ -151,7 +151,7 @@ func (b *Backend) normalizeBlockNumber(blockNumber rpc.BlockNumber) (int64, erro
 
 // HeaderByNumber gets the canonical header for the provided block number
 func (b *Backend) HeaderByNumber(ctx context.Context, blockNumber rpc.BlockNumber) (*types.Header, error) {
-	number, err := b.normalizeBlockNumber(blockNumber)
+	number, err := b.NormalizeBlockNumber(blockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func (b *Backend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.Blo
 
 // BlockByNumber returns the requested canonical block
 func (b *Backend) BlockByNumber(ctx context.Context, blockNumber rpc.BlockNumber) (*types.Block, error) {
-	number, err := b.normalizeBlockNumber(blockNumber)
+	number, err := b.NormalizeBlockNumber(blockNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/eth/sql.go
+++ b/pkg/eth/sql.go
@@ -122,8 +122,8 @@ const (
 	RetrieveFilteredLogs = `SELECT CAST(eth.log_cids.block_number as TEXT), eth.log_cids.cid, eth.log_cids.index, eth.log_cids.rct_id,
 			eth.log_cids.address, eth.log_cids.topic0, eth.log_cids.topic1, eth.log_cids.topic2, eth.log_cids.topic3,
 			eth.transaction_cids.tx_hash, eth.transaction_cids.index as txn_index,
-			blocks.data, eth.receipt_cids.cid AS rct_cid, eth.receipt_cids.post_status, eth.log_cids.header_id AS block_hash
-							FROM eth.log_cids, eth.receipt_cids, eth.transaction_cids, ipld.blocks
+			blocks.data, eth.receipt_cids.cid AS rct_cid, eth.receipt_cids.post_status, header_cids.block_hash
+							FROM eth.log_cids, eth.receipt_cids, eth.transaction_cids, eth.header_cids, ipld.blocks
 							WHERE eth.log_cids.rct_id = receipt_cids.tx_id
 							AND eth.log_cids.header_id = eth.receipt_cids.header_id
 							AND eth.log_cids.block_number = eth.receipt_cids.block_number
@@ -132,9 +132,8 @@ const (
 							AND receipt_cids.tx_id = transaction_cids.tx_hash
 							AND receipt_cids.header_id = transaction_cids.header_id
 							AND receipt_cids.block_number = transaction_cids.block_number
-							AND transaction_cids.header_id = log_cids.header_id
-							AND transaction_cids.header_id = (SELECT canonical_header_hash(transaction_cids.block_number))
-							AND transaction_cids.block_number = log_cids.block_number`
+							AND transaction_cids.header_id = header_cids.block_hash
+							AND transaction_cids.block_number = header_cids.block_number`
 	RetrieveStorageLeafByAddressHashAndLeafKeyAndBlockHashPgStr   = `SELECT cid, val, block_number, removed, state_leaf_removed FROM get_storage_at_by_hash($1, $2, $3)`
 	RetrieveStorageAndRLPByAddressHashAndLeafKeyAndBlockHashPgStr = `
 SELECT cid, val, storage.block_number, removed, state_leaf_removed, data

--- a/pkg/eth/sql.go
+++ b/pkg/eth/sql.go
@@ -133,6 +133,7 @@ const (
 							AND receipt_cids.header_id = transaction_cids.header_id
 							AND receipt_cids.block_number = transaction_cids.block_number
 							AND transaction_cids.header_id = log_cids.header_id
+							AND transaction_cids.header_id = (SELECT canonical_header_hash(transaction_cids.block_number))
 							AND transaction_cids.block_number = log_cids.block_number`
 	RetrieveStorageLeafByAddressHashAndLeafKeyAndBlockHashPgStr   = `SELECT cid, val, block_number, removed, state_leaf_removed FROM get_storage_at_by_hash($1, $2, $3)`
 	RetrieveStorageAndRLPByAddressHashAndLeafKeyAndBlockHashPgStr = `

--- a/pkg/eth/sql.go
+++ b/pkg/eth/sql.go
@@ -122,8 +122,8 @@ const (
 	RetrieveFilteredLogs = `SELECT CAST(eth.log_cids.block_number as TEXT), eth.log_cids.cid, eth.log_cids.index, eth.log_cids.rct_id,
 			eth.log_cids.address, eth.log_cids.topic0, eth.log_cids.topic1, eth.log_cids.topic2, eth.log_cids.topic3,
 			eth.transaction_cids.tx_hash, eth.transaction_cids.index as txn_index,
-			blocks.data, eth.receipt_cids.cid AS rct_cid, eth.receipt_cids.post_status, header_cids.block_hash
-							FROM eth.log_cids, eth.receipt_cids, eth.transaction_cids, eth.header_cids, ipld.blocks
+			blocks.data, eth.receipt_cids.cid AS rct_cid, eth.receipt_cids.post_status, eth.log_cids.header_id AS block_hash
+							FROM eth.log_cids, eth.receipt_cids, eth.transaction_cids, ipld.blocks
 							WHERE eth.log_cids.rct_id = receipt_cids.tx_id
 							AND eth.log_cids.header_id = eth.receipt_cids.header_id
 							AND eth.log_cids.block_number = eth.receipt_cids.block_number
@@ -132,8 +132,8 @@ const (
 							AND receipt_cids.tx_id = transaction_cids.tx_hash
 							AND receipt_cids.header_id = transaction_cids.header_id
 							AND receipt_cids.block_number = transaction_cids.block_number
-							AND transaction_cids.header_id = header_cids.block_hash
-							AND transaction_cids.block_number = header_cids.block_number`
+							AND transaction_cids.header_id = log_cids.header_id
+							AND transaction_cids.block_number = log_cids.block_number`
 	RetrieveStorageLeafByAddressHashAndLeafKeyAndBlockHashPgStr   = `SELECT cid, val, block_number, removed, state_leaf_removed FROM get_storage_at_by_hash($1, $2, $3)`
 	RetrieveStorageAndRLPByAddressHashAndLeafKeyAndBlockHashPgStr = `
 SELECT cid, val, storage.block_number, removed, state_leaf_removed, data

--- a/pkg/serve/config.go
+++ b/pkg/serve/config.go
@@ -158,7 +158,7 @@ func NewConfig() (*Config, error) {
 	if viper.IsSet("ethereum.getLogsBlockLimit") {
 		c.GetLogsBlockLimit = viper.GetInt64("ethereum.getLogsBlockLimit")
 	} else {
-		c.GetLogsBlockLimit = 100
+		c.GetLogsBlockLimit = 500
 	}
 
 	// websocket server

--- a/pkg/serve/config.go
+++ b/pkg/serve/config.go
@@ -56,6 +56,7 @@ const (
 	ETH_FORWARD_ETH_CALLS      = "ETH_FORWARD_ETH_CALLS"
 	ETH_FORWARD_GET_STORAGE_AT = "ETH_FORWARD_GET_STORAGE_AT"
 	ETH_PROXY_ON_ERROR         = "ETH_PROXY_ON_ERROR"
+	ETH_GETLOGS_BLOCK_LIMIT    = "ETH_GETLOGS_BLOCK_LIMIT"
 
 	VALIDATOR_ENABLED         = "VALIDATOR_ENABLED"
 	VALIDATOR_EVERY_NTH_BLOCK = "VALIDATOR_EVERY_NTH_BLOCK"
@@ -107,6 +108,7 @@ type Config struct {
 	ForwardEthCalls     bool
 	ForwardGetStorageAt bool
 	ProxyOnError        bool
+	GetLogsBlockLimit   int64
 	NodeNetworkID       string
 
 	// Cache configuration.
@@ -134,6 +136,7 @@ func NewConfig() (*Config, error) {
 	viper.BindEnv("ethereum.forwardEthCalls", ETH_FORWARD_ETH_CALLS)
 	viper.BindEnv("ethereum.forwardGetStorageAt", ETH_FORWARD_GET_STORAGE_AT)
 	viper.BindEnv("ethereum.proxyOnError", ETH_PROXY_ON_ERROR)
+	viper.BindEnv("ethereum.getLogsBlockLimit", ETH_GETLOGS_BLOCK_LIMIT)
 	viper.BindEnv("log.file", "LOG_FILE")
 	viper.BindEnv("log.level", "LOG_LEVEL")
 
@@ -151,6 +154,12 @@ func NewConfig() (*Config, error) {
 	c.ForwardGetStorageAt = viper.GetBool("ethereum.forwardGetStorageAt")
 	c.ProxyOnError = viper.GetBool("ethereum.proxyOnError")
 	c.EthHttpEndpoint = ethHTTPEndpoint
+
+	if viper.IsSet("ethereum.getLogsBlockLimit") {
+		c.GetLogsBlockLimit = viper.GetInt64("ethereum.getLogsBlockLimit")
+	} else {
+		c.GetLogsBlockLimit = 100
+	}
 
 	// websocket server
 	wsEnabled := viper.GetBool("server.ws")

--- a/pkg/serve/service.go
+++ b/pkg/serve/service.go
@@ -72,6 +72,8 @@ type Service struct {
 	forwardEthCalls bool
 	// whether to forward eth_getStorageAt directly to proxy node
 	forwardGetStorageAt bool
+	// the maximum size of the block range to use in GetLogs
+	getLogsBlockLimit int64
 	// whether to forward all calls to proxy node if they throw an error locally
 	proxyOnError bool
 	// eth node network id
@@ -88,6 +90,7 @@ func NewServer(settings *Config) (Server, error) {
 	sap.stateDiffTimeout = settings.StateDiffTimeout
 	sap.forwardEthCalls = settings.ForwardEthCalls
 	sap.forwardGetStorageAt = settings.ForwardGetStorageAt
+	sap.getLogsBlockLimit = settings.GetLogsBlockLimit
 	sap.proxyOnError = settings.ProxyOnError
 	sap.nodeNetworkId = settings.NodeNetworkID
 	var err error
@@ -128,6 +131,7 @@ func (sap *Service) APIs() []rpc.API {
 		ForwardGetStorageAt: sap.forwardGetStorageAt,
 		ProxyOnError:        sap.proxyOnError,
 		StateDiffTimeout:    sap.stateDiffTimeout,
+		GetLogsBlockLimit:   sap.getLogsBlockLimit,
 	}
 	ethAPI, err := eth.NewPublicEthAPI(sap.backend, sap.client, conf)
 	if err != nil {


### PR DESCRIPTION
Fix for #248 and #249.

This does a few things:

1) Support for "earliest", "latest", etc. block specifiers.  This did not work before.

2) The default "fromBlock" is now "latest" to match geth.

3) The old code did a loop across fromBlock:toBlock, executing a query on each one inside a big tx (!).  This does a single query, with no separate tx.

4) Add a max range limit (default 500) with an error message if the range is too broad (I used the same error message as cloudflare)

5) Simplify the query a good bit.  This improved performance significantly in my manual testing adapted to v4.  The old version, adapted to use a small range of 50 blocks took over 20s.  The new version took about 700ms.  A query across 500 blocks with 150K results takes less than 4s.

Some additional test cases added here: https://git.vdb.to/cerc-io/system-tests/src/branch/main/test/test_logs.py