### PR TITLE
251: Remove uses of canonical_header_hash() and get_storage_at() fns in light of v5 schema updates.

### DIFF
--- a/pkg/eth/retriever.go
+++ b/pkg/eth/retriever.go
@@ -266,9 +266,6 @@ func (r *Retriever) retrieveFilteredLogs(db *sqlx.DB, rctFilter ReceiptFilter, s
 
 	pgStr, args = logFilterCondition(&id, pgStr, args, rctFilter)
 	pgStr += ` ORDER BY eth.log_cids.block_number, eth.log_cids.index`
-	if blockHash != nil {
-		pgStr += ` LIMIT 1`
-	}
 
 	logs := make([]LogResult, 0)
 	err := db.Select(&logs, pgStr, args...)

--- a/pkg/eth/retriever.go
+++ b/pkg/eth/retriever.go
@@ -266,6 +266,9 @@ func (r *Retriever) retrieveFilteredLogs(db *sqlx.DB, rctFilter ReceiptFilter, s
 
 	pgStr, args = logFilterCondition(&id, pgStr, args, rctFilter)
 	pgStr += ` ORDER BY eth.log_cids.block_number, eth.log_cids.index`
+	if blockHash != nil {
+		pgStr += ` LIMIT 1`
+	}
 
 	logs := make([]LogResult, 0)
 	err := db.Select(&logs, pgStr, args...)

--- a/pkg/eth/sql.go
+++ b/pkg/eth/sql.go
@@ -1,13 +1,17 @@
 package eth
 
 const (
-	RetrieveHeaderByHashPgStr = `SELECT cid, data
-								FROM eth.header_cids
-									INNER JOIN ipld.blocks ON (
-										header_cids.cid = blocks.key
-										AND header_cids.block_number = blocks.block_number
-									)
-								WHERE block_hash = $1`
+	RetrieveHeaderByHashPgStr = `
+SELECT header_cids.cid,
+	blocks.data
+FROM ipld.blocks,
+	eth.header_cids
+WHERE header_cids.block_hash = $1
+	AND header_cids.canonical
+	AND blocks.key = header_cids.cid
+	AND blocks.block_number = header_cids.block_number
+LIMIT 1
+`
 	RetrieveUnclesPgStr = `SELECT uncle_cids.cid, data
 										FROM eth.uncle_cids
 											INNER JOIN eth.header_cids ON (
@@ -35,79 +39,94 @@ const (
 										WHERE header_cids.block_hash = $1
 										ORDER BY uncle_cids.parent_hash
 										LIMIT 1`
-	RetrieveTransactionsPgStr = `SELECT transaction_cids.cid, data
-											FROM eth.transaction_cids
-												INNER JOIN eth.header_cids ON (
-													transaction_cids.header_id = header_cids.block_hash
-													AND transaction_cids.block_number = header_cids.block_number
-												)
-												INNER JOIN ipld.blocks ON (
-													transaction_cids.cid = blocks.key
-													AND transaction_cids.block_number = blocks.block_number
-												)
-											WHERE block_hash = $1
-											AND header_cids.block_number = $2
-											ORDER BY eth.transaction_cids.index ASC`
-	RetrieveTransactionsByBlockHashPgStr = `SELECT transaction_cids.cid, data
-											FROM eth.transaction_cids
-												INNER JOIN eth.header_cids ON (
-													transaction_cids.header_id = header_cids.block_hash
-													AND transaction_cids.block_number = header_cids.block_number
-												)
-												INNER JOIN ipld.blocks ON (
-													transaction_cids.cid = blocks.key
-													AND transaction_cids.block_number = blocks.block_number
-												)
-											WHERE block_hash = $1
-											ORDER BY eth.transaction_cids.index ASC`
-	RetrieveReceiptsPgStr = `SELECT receipt_cids.cid, data, eth.transaction_cids.tx_hash
-										FROM eth.receipt_cids
-											INNER JOIN eth.transaction_cids ON (
-												receipt_cids.tx_id = transaction_cids.tx_hash
-												AND receipt_cids.header_id = transaction_cids.header_id
-												AND receipt_cids.block_number = transaction_cids.block_number
-											)
-											INNER JOIN eth.header_cids ON (
-												transaction_cids.header_id = header_cids.block_hash
-												AND transaction_cids.block_number = header_cids.block_number
-											)
-											INNER JOIN ipld.blocks ON (
-												receipt_cids.cid = blocks.key
-												AND receipt_cids.block_number = blocks.block_number
-											)
-										WHERE block_hash = $1
-										AND header_cids.block_number = $2
-										ORDER BY eth.transaction_cids.index ASC`
-	RetrieveReceiptsByBlockHashPgStr = `SELECT receipt_cids.cid, data, eth.transaction_cids.tx_hash
-										FROM eth.receipt_cids
-											INNER JOIN eth.transaction_cids ON (
-												receipt_cids.tx_id = transaction_cids.tx_hash
-												AND receipt_cids.header_id = transaction_cids.header_id
-												AND receipt_cids.block_number = transaction_cids.block_number
-											)
-											INNER JOIN eth.header_cids ON (
-												transaction_cids.header_id = header_cids.block_hash
-												AND transaction_cids.block_number = header_cids.block_number
-											)
-											INNER JOIN ipld.blocks ON (
-												receipt_cids.cid = blocks.key
-												AND receipt_cids.block_number = blocks.block_number
-											)
-										WHERE block_hash = $1
-										ORDER BY eth.transaction_cids.index ASC`
-	RetrieveAccountByLeafKeyAndBlockHashPgStr = `SELECT state_cids.nonce, state_cids.balance, state_cids.storage_root, state_cids.code_hash, state_cids.removed
-												   FROM eth.state_cids
-														INNER JOIN eth.header_cids ON (
-														  state_cids.header_id = header_cids.block_hash
-														  AND state_cids.block_number = header_cids.block_number
-														)
-												  WHERE state_leaf_key = $1
-													AND header_cids.block_number <= (SELECT block_number
-																					   FROM eth.header_cids
-																					  WHERE block_hash = $2)
-													AND header_cids.block_hash = (SELECT canonical_header_hash(header_cids.block_number))
-												  ORDER BY header_cids.block_number DESC
-												  LIMIT 1`
+	RetrieveTransactionsPgStr = `
+SELECT transaction_cids.cid,
+	blocks.data
+FROM eth.transaction_cids,
+	eth.header_cids,
+	ipld.blocks
+WHERE header_cids.block_hash = $1
+    AND header_cids.block_number = $2
+	AND header_cids.canonical
+	AND transaction_cids.block_number = header_cids.block_number
+	AND transaction_cids.header_id = header_cids.block_hash
+	AND blocks.block_number = header_cids.block_number
+	AND blocks.key = transaction_cids.cid
+ORDER BY eth.transaction_cids.index ASC
+`
+	RetrieveTransactionsByBlockHashPgStr = `
+SELECT transaction_cids.cid,
+	blocks.data
+FROM eth.transaction_cids,
+	eth.header_cids,
+	ipld.blocks
+WHERE header_cids.block_hash = $1
+	AND header_cids.canonical
+	AND transaction_cids.block_number = header_cids.block_number
+	AND transaction_cids.header_id = header_cids.block_hash
+	AND blocks.block_number = header_cids.block_number
+	AND blocks.key = transaction_cids.cid
+ORDER BY eth.transaction_cids.index ASC
+`
+	RetrieveReceiptsPgStr = `
+SELECT receipt_cids.cid,
+	blocks.data,
+	eth.transaction_cids.tx_hash
+FROM eth.receipt_cids,
+	eth.transaction_cids,
+	eth.header_cids,
+	ipld.blocks
+WHERE header_cids.block_hash = $1
+	AND header_cids.block_number = $2
+	AND header_cids.canonical
+	AND receipt_cids.block_number = header_cids.block_number
+	AND receipt_cids.header_id = header_cids.block_hash
+	AND receipt_cids.TX_ID = transaction_cids.TX_HASH
+	AND transaction_cids.block_number = header_cids.block_number
+	AND transaction_cids.header_id = header_cids.block_hash
+	AND blocks.block_number = header_cids.block_number
+	AND blocks.key = receipt_cids.cid
+ORDER BY eth.transaction_cids.index ASC
+`
+	RetrieveReceiptsByBlockHashPgStr = `
+SELECT receipt_cids.cid,
+	blocks.data,
+	eth.transaction_cids.tx_hash
+FROM eth.receipt_cids,
+	eth.transaction_cids,
+	eth.header_cids,
+	ipld.blocks
+WHERE header_cids.block_hash = $1
+	AND header_cids.canonical
+	AND receipt_cids.block_number = header_cids.block_number
+	AND receipt_cids.header_id = header_cids.block_hash
+	AND receipt_cids.TX_ID = transaction_cids.TX_HASH
+	AND transaction_cids.block_number = header_cids.block_number
+	AND transaction_cids.header_id = header_cids.block_hash
+	AND blocks.block_number = header_cids.block_number
+	AND blocks.key = receipt_cids.cid
+ORDER BY eth.transaction_cids.index ASC
+`
+	RetrieveAccountByLeafKeyAndBlockHashPgStr = `
+SELECT state_cids.nonce,
+	state_cids.balance,
+	state_cids.storage_root,
+	state_cids.code_hash,
+	state_cids.removed
+FROM eth.state_cids,
+	eth.header_cids
+WHERE state_cids.state_leaf_key = $1
+	AND state_cids.block_number <=
+		(SELECT block_number
+			FROM eth.header_cids
+			WHERE block_hash = $2
+			LIMIT 1)
+	AND header_cids.canonical
+	AND state_cids.header_id = header_cids.block_hash
+	AND state_cids.block_number = header_cids.block_number
+ORDER BY state_cids.block_number DESC
+LIMIT 1
+`
 	RetrieveFilteredGQLLogs = `SELECT CAST(eth.log_cids.block_number as TEXT), eth.log_cids.header_id as block_hash,
 			eth.log_cids.cid, eth.log_cids.index, eth.log_cids.rct_id, eth.log_cids.address,
 			eth.log_cids.topic0, eth.log_cids.topic1, eth.log_cids.topic2, eth.log_cids.topic3,
@@ -125,7 +144,7 @@ const (
 			ipld.blocks.data, eth.receipt_cids.cid AS rct_cid, eth.receipt_cids.post_status, log_cids.header_id AS block_hash
 							FROM eth.log_cids, eth.receipt_cids, eth.transaction_cids, ipld.blocks
 							WHERE eth.log_cids.block_number >= $1 AND eth.log_cids.block_number <= $2
-							AND eth.log_cids.header_id IN (SELECT canonical_header_hash(block_number) from eth.header_cids where eth.header_cids.block_number >= $1 AND header_cids.block_number <= $2)
+							AND eth.log_cids.header_id IN (SELECT block_hash from eth.header_cids where eth.header_cids.block_number >= $1 AND eth.header_cids.block_number <= $2 and eth.header_cids.canonical)
 							AND eth.transaction_cids.block_number = eth.log_cids.block_number
 							AND eth.transaction_cids.header_id = eth.log_cids.header_id
 							AND eth.receipt_cids.block_number = eth.log_cids.block_number
@@ -157,39 +176,63 @@ SELECT cid, val, storage.block_number, removed, state_leaf_removed, data
          storage.cid = blocks.key
          AND storage.block_number = blocks.block_number
        )`
-	RetrieveCanonicalBlockHashByNumber = `SELECT block_hash
-									FROM canonical_header_hash($1) AS block_hash
-									WHERE block_hash IS NOT NULL`
-	RetrieveCanonicalHeaderByNumber = `SELECT cid, data FROM eth.header_cids
-									INNER JOIN ipld.blocks ON (
-										header_cids.cid = blocks.key
-										AND header_cids.block_number = blocks.block_number
-									)
-									WHERE block_hash = (SELECT canonical_header_hash($1))`
-	RetrieveCanonicalHeaderAndHashByNumber = `SELECT data, block_hash FROM eth.header_cids
-									INNER JOIN ipld.blocks ON (
-										header_cids.cid = blocks.key
-										AND header_cids.block_number = blocks.block_number
-									)
-									WHERE block_hash = (SELECT canonical_header_hash($1))`
+	RetrieveCanonicalBlockHashByNumber = `SELECT block_hash FROM eth.header_cids WHERE block_number = $1 and canonical`
+	RetrieveCanonicalHeaderByNumber    = `
+SELECT header_cids.cid,
+	blocks.data
+FROM ipld.blocks,
+	eth.header_cids
+WHERE header_cids.block_number = $1
+	AND header_cids.canonical
+	AND blocks.key = header_cids.cid
+	AND blocks.block_number = header_cids.block_number
+LIMIT 1
+`
+	RetrieveCanonicalHeaderAndHashByNumber = `
+SELECT blocks.data,
+       header_cids.block_hash
+FROM ipld.blocks,
+	eth.header_cids
+WHERE header_cids.block_number = $1
+	AND header_cids.canonical
+	AND blocks.key = header_cids.cid
+	AND blocks.block_number = header_cids.block_number
+LIMIT 1
+`
 	RetrieveTD = `SELECT CAST(td as TEXT) FROM eth.header_cids
 			WHERE header_cids.block_hash = $1`
-	RetrieveRPCTransaction = `SELECT blocks.data, header_id, transaction_cids.block_number, index
-			FROM ipld.blocks, eth.transaction_cids
-			WHERE blocks.key = transaction_cids.cid
-			AND blocks.block_number = transaction_cids.block_number
-			AND transaction_cids.tx_hash = $1
-			AND transaction_cids.header_id = (SELECT canonical_header_hash(transaction_cids.block_number))`
-	RetrieveCodeHashByLeafKeyAndBlockHash = `SELECT code_hash FROM eth.state_cids, eth.header_cids
-											WHERE state_cids.header_id = header_cids.block_hash
-											AND state_cids.block_number = header_cids.block_number
-											AND state_leaf_key = $1
-											AND header_cids.block_number <= (SELECT block_number
-																FROM eth.header_cids
-																WHERE block_hash = $2)
-											AND header_cids.block_hash = (SELECT canonical_header_hash(header_cids.block_number))
-											ORDER BY header_cids.block_number DESC
-											LIMIT 1`
+	RetrieveRPCTransaction = `
+SELECT blocks.data,
+	transaction_cids.header_id,
+	transaction_cids.block_number,
+	transaction_cids.index
+FROM eth.transaction_cids,
+    ipld.blocks,
+	eth.header_cids
+WHERE transaction_cids.TX_HASH = $1
+	AND header_cids.block_hash = transaction_cids.header_id
+	AND header_cids.block_number = transaction_cids.block_number
+	AND header_cids.canonical
+        AND blocks.key = transaction_cids.cid
+	AND blocks.block_number = transaction_cids.block_number
+`
+	RetrieveCodeHashByLeafKeyAndBlockHash = `
+SELECT state_cids.code_hash
+FROM eth.state_cids,
+	eth.header_cids
+WHERE
+state_cids.state_leaf_key = $1
+	AND state_cids.block_number <=
+		(SELECT block_number
+			FROM eth.header_cids
+			WHERE block_hash = $2
+			LIMIT 1)
+	AND header_cids.canonical
+	AND state_cids.header_id = header_cids.block_hash
+	AND state_cids.block_number = header_cids.block_number
+ORDER BY state_cids.block_number DESC
+LIMIT 1
+`
 	RetrieveCodeByKey = `SELECT data FROM ipld.blocks WHERE key = $1`
 )
 


### PR DESCRIPTION
This refactors a number of queries in light of v5 schema updates.  In particular it removes all uses of the canonical_header_hash() and get_storage_at() functions.

I have `EXPLAIN ANALYZED` all the new queries, and they seem reasonably efficient with no major red flags, though undoubtedly efficiency can be improved with more analysis.